### PR TITLE
[2단계 - JDBC 라이브러리 구현하기] 구름(김민수) 미션 제출합니다.

### DIFF
--- a/jdbc/src/test/java/com/interface21/jdbc/core/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/com/interface21/jdbc/core/JdbcTemplateTest.java
@@ -1,5 +1,69 @@
 package com.interface21.jdbc.core;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 class JdbcTemplateTest {
 
+    private PreparedStatement preparedStatement;
+    private ResultSet resultSet;
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        DataSource dataSource = mock(DataSource.class);
+        Connection connection = mock(Connection.class);
+        preparedStatement = mock(PreparedStatement.class);
+        resultSet = mock(ResultSet.class);
+
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.prepareStatement(anyString())).thenReturn(preparedStatement);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+
+        jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    @Test
+    void query() throws SQLException {
+        when(resultSet.next()).thenReturn(true, false);
+        when(resultSet.getString("name")).thenReturn("test");
+
+        String sql = "SELECT name FROM users";
+        List<String> results = jdbcTemplate.query(sql, rs -> rs.getString("name"));
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0)).isEqualTo("test");
+    }
+
+    @Test
+    void queryForObject() throws SQLException {
+        when(resultSet.next()).thenReturn(true, false);
+        when(resultSet.getString("name")).thenReturn("test");
+
+        String sql = "SELECT name FROM users WHERE id = 1";
+        String result = jdbcTemplate.queryForObject(sql, rs -> rs.getString("name"));
+
+        assertThat(result).isEqualTo("test");
+    }
+
+    @Test
+    void update() throws SQLException {
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+
+        String sql = "UPDATE users SET name = ? WHERE id = ?";
+        int rowsAffected = jdbcTemplate.update(sql, "newName", 1);
+
+        assertThat(rowsAffected).isEqualTo(1);
+    }
 }


### PR DESCRIPTION
안녕하세요 무빈! 구름 ⛅️입니다.

step1에서 step2 부분을 해버린 것 같아서 죄송합니다.
step2 설명에는 JdbcTemplate이 추상클래스인 것 같은데 왜 그런지 잘 모르겠습니다. 
JdbcTemplateTest를 작성해봤는데 mock을 사용해서 좋은 테스트인지 모르겠네요.

### JDBC라이브러리 구현 부분
step2에서 JDBC라이브러리에서 다음의 동작을 수행해야할 것 같습니다.
여기서 트랜잭션 부분은 다음 step이라 제외하고 구현했습니다.

- Connection 생성 ✅
- Statement 준비 및 실행 ✅
- ResultSet 생성 ✅
- 예외 처리 ✅
- 트랜잭션 관리 ❌
- Connection, Statement, ResultSet 객체 close ✅

### 라이브러리 확장 부분
- SQLException은 Checked Exception이다. 커스텀 Exception을 추가해서 사용자는 Unchecked Exception이 되도록 변경하자.
  -> DataAccessException으로 변경
- RowMapper 인터페이스는 Object를 반환하고 있어서 캐스팅이 사용된다. 제네릭을 사용하도록 개선해보자.
  -> RowMapper<T>, T mapRow 사용
- 매번 PreparedStatementSetter 인터페이스를 구현하려니 번거롭다. 가변인자를 사용해서 좀더 편리하게 만들 수 없을까?
  -> query, queryForObject, update에서 가변인자 사용

```java
public <T> List<T> query(String sql, @Nullable PreparedStatementSetter pss, RowMapper<T> rowMapper) { ... }
public <T> List<T> query(String sql, RowMapper<T> rowMapper, Object... args) { ... }
public <T> List<T> query(String sql, RowMapper<T> rowMapper) { ... }
```
- 람다를 적극적으로 활용해서 코드량을 줄여보자.
  -> execute에서 pstmt -> { ... }를 사용해 익명 클래스 대신 람다로 작성

### 공부할만한 부분

#### 체크 예외 대신 언체크 예외를 사용하는 이유

Throwable 하위에 Exception과 Error가 있어요. Exception 하위에는 IOException, SQLException, RuntimeException이 있어요. 여기서 RuntimeException을 제외하고 모두 체크 예외입니다. 체크 예외는 잡아서 처리하고 않고 던지려면 throws 예외를 메서드에 필수로 선언해야 합니다.

언체크 예외를 사용하는 이유는 다음과 같아요.
1. 대부분 체크 예외는 처리할 수 없다는 것입니다. 보통 끝까지 예외가 올라가서 공통 예외 부분에서 처리됩니다. 두 번째 이유는 의존 관계에 대한 이유때문입니다. 
2. 체크 예외는 처리할 수 없어도 throws를 메서드에 명시해야합니다. 그러면 사용하는 부분에서 SQLException 같은 것들에 의존하게 됩니다. 예외가 변경된다면 문제가 될 것입니다.
