### PR TITLE
[2단계 - JDBC 라이브러리 구현하기] 카고(정민호) 미션 제출합니다.

### DIFF
--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -35,7 +35,7 @@ public class JdbcTemplate {
             pstmt.executeUpdate();
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
+            throw new DataAccessException(e);
         }
     }
 
@@ -48,7 +48,7 @@ public class JdbcTemplate {
             return findResults(pstmt, rowMapper);
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
+            throw new DataAccessException(e);
         }
     }
 
@@ -61,7 +61,7 @@ public class JdbcTemplate {
             return getOnlyOneResult(pstmt, rowMapper);
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
+            throw new DataAccessException(e);
         }
     }
 

--- a/study/src/main/resources/schema.sql
+++ b/study/src/main/resources/schema.sql
@@ -7,12 +7,12 @@ CREATE TABLE IF NOT EXISTS users (
     email VARCHAR(100) NOT NULL
 ) ENGINE=INNODB;
 
-CREATE TABLE IF NOT EXISTS user_history (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    user_id BIGINT NOT NULL,
-    account VARCHAR(100) NOT NULL,
-    password VARCHAR(100) NOT NULL,
-    email VARCHAR(100) NOT NULL,
-    created_at DATETIME NOT NULL,
-    created_by VARCHAR(100) NOT NULL
-) ENGINE=INNODB;
+-- CREATE TABLE IF NOT EXISTS user_history (
+--     id BIGINT AUTO_INCREMENT PRIMARY KEY,
+--     user_id BIGINT NOT NULL,
+--     account VARCHAR(100) NOT NULL,
+--     password VARCHAR(100) NOT NULL,
+--     email VARCHAR(100) NOT NULL,
+--     created_at DATETIME NOT NULL,
+--     created_by VARCHAR(100) NOT NULL
+-- ) ENGINE=INNODB;

--- a/study/src/main/resources/schema.sql
+++ b/study/src/main/resources/schema.sql
@@ -7,12 +7,12 @@ CREATE TABLE IF NOT EXISTS users (
     email VARCHAR(100) NOT NULL
 ) ENGINE=INNODB;
 
--- CREATE TABLE IF NOT EXISTS user_history (
---     id BIGINT AUTO_INCREMENT PRIMARY KEY,
---     user_id BIGINT NOT NULL,
---     account VARCHAR(100) NOT NULL,
---     password VARCHAR(100) NOT NULL,
---     email VARCHAR(100) NOT NULL,
---     created_at DATETIME NOT NULL,
---     created_by VARCHAR(100) NOT NULL
--- ) ENGINE=INNODB;
+CREATE TABLE IF NOT EXISTS user_history (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    account VARCHAR(100) NOT NULL,
+    password VARCHAR(100) NOT NULL,
+    email VARCHAR(100) NOT NULL,
+    created_at DATETIME NOT NULL,
+    created_by VARCHAR(100) NOT NULL
+) ENGINE=INNODB;

--- a/study/src/test/java/connectionpool/stage0/Stage0Test.java
+++ b/study/src/test/java/connectionpool/stage0/Stage0Test.java
@@ -30,6 +30,15 @@ class Stage0Test {
     void driverManager() throws SQLException {
         // Class.forName("org.h2.Driver"); // JDBC 4.0 부터 생략 가능
         // DriverManager 클래스를 활용하여 static 변수의 정보를 활용하여 h2 db에 연결한다.
+
+        /*
+        Q: 자바에서 제공하는 JDBC 드라이버를 직접 다뤄본다.
+        A: DriverManager를 사용하면 URL에 맞는 적절한 JDBC 드라이버를 찾아올 수 있다.
+        DriverManager.getConnection의 코드를 보면, 찾은 JDBC 드라이버를 활용해서 Connection을 얻어오는 과정을 볼 수 있다.
+
+        +) Class.forName("org.h2.Driver"); 는 리턴 값을 활용해서 어떤 작업을 하기 위함이 아니다.
+        이 코드를 수행하면 JDBC 드라이버가 메모리로 로드되기 때문에 사용하는 것!
+         */
         try (final Connection connection = DriverManager.getConnection(H2_URL, USER, PASSWORD)) {
             assertThat(connection.isValid(1)).isTrue();
         }
@@ -50,6 +59,22 @@ class Stage0Test {
      */
     @Test
     void dataSource() throws SQLException {
+        /*
+        Q: 데이터베이스에 어떻게 연결하는가?
+        A:
+
+        Q: 왜 DataSource를 사용하는가?
+        A:
+        1. DriverManager는 데이터베이스 연결 정보를 애플리케이션 코드에서 작성해줘야 하지만
+        DataSource는 외부 설정 파일(properties, XML 등)을 통해 데이터베이스 연결을 설정할 수 있기 때문이다.
+        2. DriverManager는 각 요청마다 새로운 데이터베이스 연결을 생성하므로 트래픽이 많은 애플리케이션에서 성능 저하를 유발한다.
+        DataSource는 커넥션 풀링을 지원한다. 따라서 애플리케이션은 매번 새로운 연결을 생성할 필요 없이, 재사용 가능한 커넥션을 활용할 수 있다.
+        3. DriverManager는 단일 데이터베이스와의 연결만을 처리할 수 있다. 여러 데이터베이스를 사용하는 분산 트랜잭션 환경에서는 처리할 수 없으며, 별도의 트랜잭션 관리 시스템이 필요하다.
+        DataSource는 분산 트랜잭션을 지원한다. 여러 데이터베이스 간의 트랜잭션을 처리해야 할 때, 트랜잭션 매니저와 연동되어 각 데이터베이스에 대한 트랜잭션을 안전하게 처리할 수 있다.
+
+        +) 분산 트랜잭션이란, 단일 트랜잭션 내에서 여러 시스템 또는 데이터베이스 걸쳐 작업을 수행한다.
+        모든 참여하는 리소스에 대해 ACID 속성을 보장하는 것이 분산 트랜잭션의 핵심 목표이다.
+         */
         final JdbcDataSource dataSource = new JdbcDataSource();
         dataSource.setURL(H2_URL);
         dataSource.setUser(USER);

--- a/study/src/test/java/connectionpool/stage1/Stage1Test.java
+++ b/study/src/test/java/connectionpool/stage1/Stage1Test.java
@@ -31,8 +31,8 @@ class Stage1Test {
         final JdbcConnectionPool jdbcConnectionPool = JdbcConnectionPool.create(H2_URL, USER, PASSWORD);
 
         assertThat(jdbcConnectionPool.getActiveConnections()).isZero();
-        try (final var connection = jdbcConnectionPool.getConnection()) {
-            assertThat(connection.isValid(1)).isTrue();
+        try (final var connection = jdbcConnectionPool.getConnection()) { // 커넥션을 획득하기만 해도 activeConnection으로 분류된다.
+            assertThat(connection.isValid(1)).isTrue(); // 커넥션이 유효한지 확인한다.
             assertThat(jdbcConnectionPool.getActiveConnections()).isEqualTo(1);
         }
         assertThat(jdbcConnectionPool.getActiveConnections()).isZero();
@@ -42,6 +42,7 @@ class Stage1Test {
 
     /**
      * Spring Boot 2.0 부터 HikariCP를 기본 데이터 소스로 채택하고 있다.
+     * 이유 -> performance, concurrency
      * https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#data.sql.datasource.connection-pool
      * Supported Connection Pools
      * We prefer HikariCP for its performance and concurrency. If HikariCP is available, we always choose it.
@@ -51,12 +52,23 @@ class Stage1Test {
      *
      * HikariCP 필수 설정
      * https://github.com/brettwooldridge/HikariCP#essentials
+     * - jdbcUrl: 데이터베이스 연결 URL을 지정
+     * - username: 데이터베이스에 접속할 사용자 이름
+     * - password: 사용자 인증에 사용할 비밀번호
      *
      * HikariCP의 pool size는 몇으로 설정하는게 좋을까?
      * https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
+     * - 사용하는 데이터베이스의 처리 능력을 고려한다.
+     * - 서버 CPU 코어 수를 고려한다. 일반적으로 `CPU 코어수 + 1` 또는 `2 * CPU 코어수`로 설정한다.
+     * - 애플리케이션이 동시에 처리해야 하는 병렬요청 수를 고려한다.
+     * - 너무 큰 풀 크기는 리소스 낭비가 될 수 있고, 너무 작은 풀 크기는 병목 현상을 일으킬 수 있다.
      *
      * HikariCP를 사용할 때 적용하면 좋은 MySQL 설정
      * https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration
+     * - cachePrepStmts : MySQL에서 PreparedStatement를 캐싱하여 반복된 쿼리 실행 시 성능을 향상시킨다.
+     * - prepStmtCacheSize : 캐싱할 PreparedStatement의 최대 갯수
+     * - prepStmtCacheSqlLimit : 캐싱할 PreparedStatement에 대한 SQL 문자열의 최대 크기 지정
+     * - useServerPrepStmts : 서버 측 PreparedStatement를 사용하여 클라이언트에서 PreparedStatement를 처리하는 것보다 더 나은 성능 제공
      */
     @Test
     void testHikariCP() {

--- a/study/src/test/java/connectionpool/stage2/Stage2Test.java
+++ b/study/src/test/java/connectionpool/stage2/Stage2Test.java
@@ -23,7 +23,7 @@ class Stage2Test {
 
     /**
      * spring boot에서 설정 파일인 application.yml를 사용하여 DataSource를 설정할 수 있다.
-     * 하지만 DataSource를 여러 개 사용하거나 세부 설정을 하려면 빈을 직접 생성하는 방법을 사용한다.
+     * 하지만 DataSource를 여러 개 사용하거나 세부 설정을 하려면 빈을 직접 생성하는 방법을 사용한다. -> RDS 때문에 DataSource를 두 개 설정할 때 Config를 빈으로 등록한 이유가 이거구나
      * DataSourceConfig 클래스를 찾아서 어떻게 빈으로 직접 생성하는지 확인해보자.
      * 그리고 아래 DataSource가 직접 생성한 빈으로 주입 받았는지 getPoolName() 메서드로 확인해보자.
      */
@@ -36,6 +36,7 @@ class Stage2Test {
         final var hikariPool = getPool((HikariDataSource) dataSource);
 
         // 설정한 커넥션 풀 최대값보다 더 많은 스레드를 생성해서 동시에 디비에 접근을 시도하면 어떻게 될까?
+        // -> 최대 풀 사이즈 만큼의 커넥션만이 계속 사용된다. 따라서 15개의 쓰레드는 커넥션을 바로 획득하지 못하고 대기한다.
         final var threads = new Thread[20];
         for (int i = 0; i < threads.length; i++) {
             threads[i] = new Thread(getConnection());

--- a/study/src/test/java/transaction/stage1/Stage1Test.java
+++ b/study/src/test/java/transaction/stage1/Stage1Test.java
@@ -249,7 +249,7 @@ class Stage1Test {
 
     private static DataSource createMySQLDataSource(final JdbcDatabaseContainer<?> container) {
         final var config = new HikariConfig();
-        config.setJdbcUrl(container.getJdbcUrl());
+        config.setJdbcUrl(container.getJdbcUrl() + "?allowMultiQueries=true");
         config.setUsername(container.getUsername());
         config.setPassword(container.getPassword());
         config.setDriverClassName(container.getDriverClassName());

--- a/study/src/test/java/transaction/stage1/Stage1Test.java
+++ b/study/src/test/java/transaction/stage1/Stage1Test.java
@@ -34,10 +34,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *   Read phenomena | Dirty reads | Non-repeatable reads | Phantom reads
  * Isolation level  |             |                      |
  * -----------------|-------------|----------------------|--------------
- * Read Uncommitted |             |                      |
- * Read Committed   |             |                      |
- * Repeatable Read  |             |                      |
- * Serializable     |             |                      |
+ * Read Uncommitted |     +       |          +           |       +
+ * Read Committed   |     -       |          +           |       +
+ * Repeatable Read  |     -       |          -           |       +
+ * Serializable     |     -       |          -           |       -
  */
 class Stage1Test {
 
@@ -47,12 +47,15 @@ class Stage1Test {
 
     private void setUp(final DataSource dataSource) {
         this.dataSource = dataSource;
-        DatabasePopulatorUtils.execute(dataSource);
+        DatabasePopulatorUtils.execute(dataSource); // schema.sql을 실행시킨다.
         this.userDao = new UserDao(dataSource);
     }
 
     /**
      * 격리 수준에 따라 어떤 현상이 발생하는지 테스트를 돌려 직접 눈으로 확인하고 표를 채워보자.
+     * -> A트랜잭션이 테이블의 값을 변경하고 아직 커밋하지 않은 시점에서 B트랜잭션이 해당 값을 read했을 때
+     * 변경된 값이 읽어지는 현상이 Dirty reads다. ReadCommitted부터는 커밋되지 않은 값을 read시 읽어오지 않으므로
+     * Dirty reads가 발생하지 않는다.
      * + : 발생
      * - : 발생하지 않음
      *   Read phenomena | Dirty reads
@@ -89,10 +92,11 @@ class Stage1Test {
             // ❗️gugu 객체는 connection에서 아직 커밋하지 않은 상태다.
             // 격리 레벨에 따라 커밋하지 않은 gugu 객체를 조회할 수 있다.
             // 사용자B가 사용자A가 커밋하지 않은 데이터를 조회하는게 적절할까?
+            // -> 적절하지 않다. 사용자A의 트랜잭션이 롤백된다면, gugu 객체는 실제로 존재하지 않는 값이 되기 때문이다.
             final var actual = userDao.findByAccount(subConnection, "gugu");
 
             // 트랜잭션 격리 레벨에 따라 아래 테스트가 통과한다.
-            // 어떤 격리 레벨일 때 다른 연결의 커밋 전 데이터를 조회할 수 있을지 찾아보자.
+            // 어떤 격리 레벨일 때 다른 연결의 커밋 전 데이터를 조회할 수 있을지 찾아보자. -> Read uncommitted
             // 다른 격리 레벨은 어떤 결과가 나오는지 직접 확인해보자.
             log.info("isolation level : {}, user : {}", isolationLevel, actual);
             assertThat(actual).isNull();
@@ -100,7 +104,7 @@ class Stage1Test {
 
         sleep(0.5);
 
-        // 롤백하면 사용자A의 user 데이터를 저장하지 않았는데 사용자B는 user 데이터가 있다고 인지한 상황이 된다.
+        // 롤백하면 사용자A의 user 데이터를 저장하지 않았는데 사용자B는 user 데이터가 있다고 인지한 상황이 된다. -> Read uncommitted 일 때 발생하는 현상
         connection.rollback();
     }
 
@@ -158,6 +162,11 @@ class Stage1Test {
 
         // 트랜잭션 격리 레벨에 따라 아래 테스트가 통과한다.
         // 각 격리 레벨은 어떤 결과가 나오는지 직접 확인해보자.
+        /*
+        변경된 패스워드가 읽어지면, Non-repeatable reads 현상이 발생한다고 본다.
+        하나의 트랜잭션이 작업하는 동안에도 다른 트랜잭션의 커밋에 영향을 받아 반복된 read 작업을 할 때마다 값이 달라질 수 있는 현상이다.
+        하나의 트랜잭션에서 같은 데이터나 테이블을 여러 번 조회해야 할 때, 데이터 정합성이 중요한 요소라면 Repeatable read가 보장되어야 한다.
+         */
         log.info("isolation level : {}, user : {}", isolationLevel, actual);
         assertThat(actual.getPassword()).isEqualTo("password");
 
@@ -166,10 +175,11 @@ class Stage1Test {
 
     /**
      * phantom read는 h2에서 발생하지 않는다. mysql로 확인해보자.
+     * phantom read : 특정 트랜잭션이 실행되는 동안, 다른 트랜잭션이 데이터를 삽입하거나 삭제하여 첫 번째 트랜잭션이 결과를 조회할 때 예상과 다른 결과를 얻게 되는 현상
      * 격리 수준에 따라 어떤 현상이 발생하는지 테스트를 돌려 직접 눈으로 확인하고 표를 채워보자.
      * + : 발생
      * - : 발생하지 않음
-     *   Read phenomena | Phantom reads
+     * Read phenomena | Phantom reads
      * Isolation level  |
      * -----------------|--------------
      * Read Uncommitted |       +
@@ -229,6 +239,7 @@ class Stage1Test {
 
         // 트랜잭션 격리 레벨에 따라 아래 테스트가 통과한다.
         // 각 격리 레벨은 어떤 결과가 나오는지 직접 확인해보자.
+        // Serializable의 경우에만 1이 나오고, 그 외에는 2개의 데이터가 조회된다. (bird도 조회된다)
         log.info("isolation level : {}, user : {}", isolationLevel, actual);
         assertThat(actual).hasSize(1);
 


### PR DESCRIPTION
안녕하세요 폴라! 2단계로 돌아왔습니다.

의도하지 않았는데, 1단계에서 기존 JdbcTemplate의 구조를 많이 따라하다보니, 2단계 리팩터링에서 요구하는 요구사항들이 거의 다 만족되어 있더라구요. 그래서 기존에 SQLException을 잡아서 RuntimeException으로 날리던 부분을 DataAccessException이라는 커스텀 예외를 날리는 정도로 변경한 것 외에는 코드 상으로 변경된 점이 없습니다! (그래도 LMS 내용을 꼼꼼히 보고 학습해보았습니다..!)

추가로 DM에서 이야기 나눴던 것처럼, 학습테스트에 주석으로 학습한 내용을 추가했습니다! phantomReading 테스트에서 schema.sql 쪽에 에러가 나던 부분은 schema.sql의 주석에 적힌 설명대로, 아래와 같이 멀티쿼리 옵션을 수행하도록 변경해서 해결했습니다! 
```java
config.setJdbcUrl(container.getJdbcUrl() + "?allowMultiQueries=true");
```

참고로 schema.sql에 적혀있던 주석 내용은 다음과 같습니다.
```
-- mysql 8.0.30부터는 statement.execute()으로 여러 쿼리를 한 번에 실행할 수 없다.
-- 멀티 쿼리 옵션을 url로 전달하도록 수정하는 방법을 찾아서 적용하자.
```

리뷰할 내용이 거의 없을 것 같긴 하지만, 잘 부탁드립니다!!