### PR TITLE
[2단계 - JDBC 라이브러리 구현하기] 이든(최승준) 미션 제출합니다.

### DIFF
--- a/jdbc/src/main/java/com/interface21/jdbc/core/ArgumentPreparedStatementSetter.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/ArgumentPreparedStatementSetter.java
@@ -1,0 +1,20 @@
+package com.interface21.jdbc.core;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import javax.annotation.Nullable;
+
+public class ArgumentPreparedStatementSetter implements PreparedStatementSetter {
+    private final Object[] args;
+
+    public ArgumentPreparedStatementSetter(@Nullable Object[] args) {
+        this.args = args;
+    }
+
+    @Override
+    public void setValues(PreparedStatement pstmt) throws SQLException {
+        for (int idx = 1; idx <= args.length; idx++) {
+            pstmt.setObject(idx, args[idx - 1]);
+        }
+    }
+}

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -29,10 +29,7 @@ public class JdbcTemplate {
         final PreparedStatement pstmt = getPreparedStatement(sql, conn);
 
         try (conn; pstmt) {
-            log.debug("query = {}", sql);
-            PreparedStatementSetter pss = createArgsPreparedStatementSetter(args);
-            pss.setValues(pstmt);
-
+            setPreparedStatementArgs(sql, args, pstmt);
             return pstmt.executeUpdate();
         } catch (SQLException e) {
             throw new DataAccessException(e);
@@ -44,10 +41,7 @@ public class JdbcTemplate {
         final PreparedStatement pstmt = getPreparedStatement(sql, conn);
 
         try (conn; pstmt) {
-            log.debug("query = {}", sql);
-            PreparedStatementSetter pss = createArgsPreparedStatementSetter(args);
-            pss.setValues(pstmt);
-
+            setPreparedStatementArgs(sql, args, pstmt);
             return executeQuery(rowMapper, pstmt);
         } catch (SQLException e) {
             throw new DataAccessException(e);
@@ -60,15 +54,18 @@ public class JdbcTemplate {
         final PreparedStatement pstmt = getPreparedStatement(sql, conn);
 
         try (conn; pstmt) {
-            log.debug("query = {}", sql);
-            PreparedStatementSetter pss = createArgsPreparedStatementSetter(args);
-            pss.setValues(pstmt);
-
+            setPreparedStatementArgs(sql, args, pstmt);
             List<T> result = executeQuery(rowMapper, pstmt);
             return requiredSingleResult(result);
         } catch (SQLException e) {
             throw new DataAccessException(e);
         }
+    }
+
+    private void setPreparedStatementArgs(String sql, Object[] args, PreparedStatement pstmt) throws SQLException {
+        log.debug("query = {}", sql);
+        PreparedStatementSetter pss = createArgsPreparedStatementSetter(args);
+        pss.setValues(pstmt);
     }
 
     private <T> List<T> executeQuery(RowMapper<T> rowMapper, PreparedStatement pstmt) throws SQLException {

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -46,7 +46,7 @@ public class JdbcTemplate {
             PreparedStatementSetter pss = createArgsPreparedStatementSetter(args);
             pss.setValues(pstmt);
 
-            return getQueryResult(rowMapper, pstmt);
+            return executeQuery(rowMapper, pstmt);
         } catch (SQLException e) {
             throw new DataAccessException("sql 실행 과정에서 문제가 발생하였습니다.", e);
         }
@@ -60,14 +60,14 @@ public class JdbcTemplate {
             PreparedStatementSetter pss = createArgsPreparedStatementSetter(args);
             pss.setValues(pstmt);
 
-            List<T> result = getQueryResult(rowMapper, pstmt);
+            List<T> result = executeQuery(rowMapper, pstmt);
             return requiredSingleResult(result);
         } catch (SQLException e) {
             throw new DataAccessException("sql 실행 과정에서 문제가 발생하였습니다.", e);
         }
     }
 
-    private <T> List<T> getQueryResult(RowMapper<T> rowMapper, PreparedStatement pstmt) throws SQLException {
+    private <T> List<T> executeQuery(RowMapper<T> rowMapper, PreparedStatement pstmt) throws SQLException {
         try (ResultSet rs = pstmt.executeQuery()) {
             List<T> result = new ArrayList<>();
             while (rs.next()) {

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -68,15 +68,14 @@ public class JdbcTemplate {
     }
 
     private <T> List<T> executeQuery(RowMapper<T> rowMapper, PreparedStatement pstmt) throws SQLException {
-        try (ResultSet rs = pstmt.executeQuery()) {
-            List<T> result = new ArrayList<>();
-            while (rs.next()) {
-                T object = rowMapper.mapRow(rs, rs.getRow());
-                result.add(object);
-            }
-
-            return result;
+        ResultSet rs = pstmt.executeQuery();
+        List<T> result = new ArrayList<>();
+        while (rs.next()) {
+            T object = rowMapper.mapRow(rs, rs.getRow());
+            result.add(object);
         }
+
+        return result;
     }
 
     private <T> T requiredSingleResult(List<T> result) {

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -88,7 +88,11 @@ public class JdbcTemplate {
         return result.get(0);
     }
 
-    public PreparedStatementSetter createArgsPreparedStatementSetter(@Nullable Object[] args) {
-        return new ArgumentPreparedStatementSetter(args);
+    public PreparedStatementSetter createArgsPreparedStatementSetter(Object[] args) {
+        return (pstmt) -> {
+            for (int idx = 1; idx <= args.length; idx++) {
+                pstmt.setObject(idx, args[idx - 1]);
+            }
+        };
     }
 }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/PreparedStatementSetter.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/PreparedStatementSetter.java
@@ -1,0 +1,8 @@
+package com.interface21.jdbc.core;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public interface PreparedStatementSetter {
+    void setValues(PreparedStatement pstmt) throws SQLException;
+}

--- a/jdbc/src/main/java/com/interface21/jdbc/core/PreparedStatementSetter.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/PreparedStatementSetter.java
@@ -3,6 +3,7 @@ package com.interface21.jdbc.core;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
+@FunctionalInterface
 public interface PreparedStatementSetter {
     void setValues(PreparedStatement pstmt) throws SQLException;
 }


### PR DESCRIPTION
안녕하세요 리건~
제가 STEP1때 고민했던 부분이 STEP2와 연관이 되어있어서 크게 많은 처리가 발생하진 않았네요

## 변경사항
### 1. PreparedStatementSetter 추가
변경 사항은 PreparedStatementSetter가 인터페이스로 분리되어서 JdbcTemplate에서 PreparedStatement에서 Args를 Pstmt에 세팅하는 책임을 분리했다는 점이구요

PreparedStatementSetter는 제가 구현한 ArgumentPreparedStatementSetter 를 사용하긴 했지만, 확장 및 사용의 편의를 위해서 FunctionalInterface로도 선언해두었습니다.

### 2. 쿼리 로그 Info -> Debug 레벨로 변경
쿼리는 서버 운영의 정보보다는 디버그를 위한 정보에 가깝다고 생각합니다.
실제로 개발을 하다보면 쿼리는 Debug레벨로 찍히기도 하구요
때문에 info 레벨로 찍어주던 쿼리를 Debug 레벨로 변경하였습니다

### 3. ResultSet Close 로직 제거
리건이 저번에 리뷰 남겨주신 부분에 대해서 이걸 좀 더 간소화할 수 없을까 고민하다가 알게 되었는데요
Statement 객체는 close 시에 ResultSet도 함께 close해주기 때문에 ResultSet Close 로직을 제거해도 괜찮다는 것을 알게 되었습니다.
모르셨다면 리건도 참고하세요:)

<img width="569" alt="스크린샷 2024-10-09 12 44 54" src="https://github.com/user-attachments/assets/2fa92ab7-4bec-44a6-8555-9e587aa57b8d">
