### PR TITLE
[2단계 - JDBC 라이브러리 구현하기] 제우스(신재우) 미션 제출합니다.

### DIFF
--- a/jdbc/src/main/java/com/interface21/dao/DataAccessException.java
+++ b/jdbc/src/main/java/com/interface21/dao/DataAccessException.java
@@ -1,7 +1,10 @@
 package com.interface21.dao;
 
+import java.io.Serial;
+
 public class DataAccessException extends RuntimeException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public DataAccessException() {

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -12,6 +12,8 @@ import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.interface21.dao.DataAccessException;
+
 public class JdbcTemplate {
 
     private static final Logger log = LoggerFactory.getLogger(JdbcTemplate.class);
@@ -68,7 +70,7 @@ public class JdbcTemplate {
             return resultSetHandler.handle(resultSet);
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
+            throw new DataAccessException(e);
         } finally {
             JdbcResourceCloser.close(connection, preparedStatement, resultSet);
         }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -26,7 +26,7 @@ public class JdbcTemplate {
     }
 
     public <T> T queryForObject(final String sql, final RowMapper<T> rowMapper, final Object... params) {
-        return execute(sql, params, resultSet -> {
+        return query(sql, defaultPreparedStatementSetter(params), resultSet -> {
             if (resultSet.next()) {
                 return rowMapper.mapRow(resultSet, resultSet.getRow());
             }
@@ -35,19 +35,30 @@ public class JdbcTemplate {
     }
 
     public <T> List<T> queryForList(final String sql, final RowMapper<T> rowMapper, final Object... params) {
-        return execute(sql, params, resultSet -> {
+        return query(sql, defaultPreparedStatementSetter(params), resultSet -> {
             List<T> result = new ArrayList<>();
-            int rowNum = 0;
             while (resultSet.next()) {
-                T row = rowMapper.mapRow(resultSet, rowNum++);
+                T row = rowMapper.mapRow(resultSet, resultSet.getRow());
                 result.add(row);
             }
             return result;
         });
     }
 
+    public <T> T query(
+            final String sql,
+            final PreparedStatementSetter preparedStatementSetter,
+            final ResultSetExtractor<T> resultSetExtractor
+    ) {
+        return execute(sql, preparedStatementSetter, resultSetExtractor);
+    }
+
     public void update(final String sql, final Object... params) {
         execute(sql, defaultPreparedStatementSetter(params), null);
+    }
+
+    public void update(final String sql, final PreparedStatementSetter preparedStatementSetter) {
+        execute(sql, preparedStatementSetter, null);
     }
 
     public <T> T execute(

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -26,16 +26,16 @@ public class JdbcTemplate {
     }
 
     public <T> T queryForObject(final String sql, final RowMapper<T> rowMapper, final Object... params) {
-        return query(sql, params, resultSet -> {
+        return execute(sql, params, resultSet -> {
             if (resultSet.next()) {
-                return rowMapper.mapRow(resultSet, 0);
+                return rowMapper.mapRow(resultSet, resultSet.getRow());
             }
             return null;
         });
     }
 
     public <T> List<T> queryForList(final String sql, final RowMapper<T> rowMapper, final Object... params) {
-        return query(sql, params, resultSet -> {
+        return execute(sql, params, resultSet -> {
             List<T> result = new ArrayList<>();
             int rowNum = 0;
             while (resultSet.next()) {
@@ -46,20 +46,16 @@ public class JdbcTemplate {
         });
     }
 
-    public <T> T query(
+    public void update(final String sql, final Object... params) {
+        execute(sql, defaultPreparedStatementSetter(params), null);
+    }
+
+    public <T> T execute(
             final String sql,
             final Object[] params,
             final ResultSetHandler<T> resultSetHandler
     ) {
         return execute(sql, defaultPreparedStatementSetter(params), resultSetHandler);
-    }
-
-    public void update(final String sql, final Object... params) {
-        update(sql, defaultPreparedStatementSetter(params));
-    }
-
-    public void update(final String sql, final PreparedStatementSetter preparedStatementSetter) {
-        execute(sql, preparedStatementSetter, null);
     }
 
     public <T> T execute(

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -53,15 +53,15 @@ public class JdbcTemplate {
     public <T> T execute(
             final String sql,
             final Object[] params,
-            final ResultSetHandler<T> resultSetHandler
+            final ResultSetExtractor<T> resultSetExtractor
     ) {
-        return execute(sql, defaultPreparedStatementSetter(params), resultSetHandler);
+        return execute(sql, defaultPreparedStatementSetter(params), resultSetExtractor);
     }
 
     public <T> T execute(
             final String sql,
             final PreparedStatementSetter preparedStatementSetter,
-            final ResultSetHandler<T> resultSetHandler
+            final ResultSetExtractor<T> resultSetExtractor
     ) {
         log.debug("query : {}", sql);
         Connection connection = null;
@@ -71,12 +71,12 @@ public class JdbcTemplate {
             connection = dataSource.getConnection();
             preparedStatement = connection.prepareStatement(sql);
             preparedStatementSetter.setValues(preparedStatement);
-            if (resultSetHandler == null) {
+            if (resultSetExtractor == null) {
                 preparedStatement.executeUpdate();
                 return null;
             }
             resultSet = preparedStatement.executeQuery();
-            return resultSetHandler.handle(resultSet);
+            return resultSetExtractor.extract(resultSet);
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
             throw new DataAccessException(e);

--- a/jdbc/src/main/java/com/interface21/jdbc/core/PreparedStatementSetter.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/PreparedStatementSetter.java
@@ -1,0 +1,9 @@
+package com.interface21.jdbc.core;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface PreparedStatementSetter {
+    void setValues(PreparedStatement preparedStatement) throws SQLException;
+}

--- a/jdbc/src/main/java/com/interface21/jdbc/core/ResultSetExtractor.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/ResultSetExtractor.java
@@ -4,6 +4,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 @FunctionalInterface
-public interface ResultSetHandler<T> {
-    T handle(ResultSet resultSet) throws SQLException;
+public interface ResultSetExtractor<T> {
+    T extract(ResultSet resultSet) throws SQLException;
 }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/ResultSetHandler.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/ResultSetHandler.java
@@ -4,6 +4,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 @FunctionalInterface
-interface ResultSetHandler<T> {
+public interface ResultSetHandler<T> {
     T handle(ResultSet resultSet) throws SQLException;
 }

--- a/jdbc/src/test/java/com/interface21/jdbc/core/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/com/interface21/jdbc/core/JdbcTemplateTest.java
@@ -44,8 +44,8 @@ class JdbcTemplateTest {
         final var saved = new User(1L, "gugu");
 
         given(resultSet.next()).willReturn(true);
-        given(resultSet.getLong(1)).willReturn(saved.id);
-        given(resultSet.getString(2)).willReturn(saved.account);
+        given(resultSet.getLong("id")).willReturn(saved.id);
+        given(resultSet.getString("account")).willReturn(saved.account);
 
         // when
         final var actual = sut.queryForObject(sql, userRowMapper, 1L);
@@ -68,8 +68,8 @@ class JdbcTemplateTest {
         final var saved3 = new User(3L, "lisa");
 
         given(resultSet.next()).willReturn(true, true, true, false);
-        given(resultSet.getLong(1)).willReturn(saved1.id, saved2.id, saved3.id);
-        given(resultSet.getString(2)).willReturn(saved1.account, saved2.account, saved3.account);
+        given(resultSet.getLong("id")).willReturn(saved1.id, saved2.id, saved3.id);
+        given(resultSet.getString("account")).willReturn(saved1.account, saved2.account, saved3.account);
 
         // when
         final var actual = sut.queryForList(sql, userRowMapper);


### PR DESCRIPTION
안녕하세요 이상 👋

LMS의 미션 설명에 해당하는 요구사항은 1단계에서 대부분 구현해서, 변경내역이 많지는 않습니다. 

다만 미션 하면서 고민했던 내용을 이야기 나눠보면 좋겠어요 🙇‍♂️

### 변경된 부분

- `PreparedStatementSetter` 인터페이스 추가
  - `JdbcTemplate.setParameters()` 구현 변경
- `JdbcTemplate.execute()`의 접근제어자를 `public`으로 변경
- `JdbcTemplate.execute()`의 `catch`문에서 `SqlException`을 `DataAccessException`으로 전환
- `ResultSetHandler` → `ResultSetExtractor` 이름 변경 및 접근제어자 `public`으로 변경

### 리뷰하며 고민한 부분

#### 1. `PreparedStatementSetter`

LMS의 설명처럼 `PreparedStatementSetter` 인터페이스를 추가했어요. [01fcd9d](https://github.com/woowacourse/java-jdbc/pull/724/commits/01fcd9dd9a4412e944a35a6a0dced17cf1b1d68d)에서 메서드 오버로딩을 통해 개발자가 `PreparedStatementSetter`와 를 직접 만들어 메서드의 파라미터로 전달할 수 있게 하려고 시도해봤어요. 그런데, `JdbcTemplate.setParameters()` 메서드처럼 파라미터를 바인딩하는 상황 외에 다른 사용 방식이 있는지는 잘 모르겠어요. 

또, 1단계 요구사항이 `개발자는 SQL 쿼리 작성, 쿼리에 전달할 인자, SELECT 구문일 경우 조회 결과를 추출하는 것만 집중할 수 있도록 라이브러리를 만들자`이었고, `JdbcTemplate`의 목적이 개발자가 JDBC API를 편리하게 사용하고 인프라와 관련된 로직은 신경쓰지 않게 해주는 것이죠. 다양한 파라미터 조합으로 메서드 오버로딩을 많이 하는 게 그 목적에 부합하는지도 의문이에요. 

그래서 현재는 execute 메서드를 통해서만 `PreparedStatement`와 `ResultSetHandler`를 커스텀해서 사용할 수 있게 구현했습니다. 

#### 2. SqlException

또, LMS의 요구사항에 따라 `execute` 메서드의 catch문에서 `SqlException`을 `DataAccessException`으로 변환했어요. 예외 메시지는 의도적으로 추가하지 않았어요. JDBC API에서 던지는 `SqlException`의 에러 메시지로 충분하고, 현재의 `JdbcTemplate`에서는 Checked Exception을 Unchecked로 전환하는 것만으로도 충분하다고 생각하기 때문이에요. 

제 생각을 줄줄이 적었는데, 이상의 생각과 다른 점이 있거나 제가 모르는 게 있거나 틀린 게 있다면 알려주시면 감사하겠습니다!!

이번 코드리뷰도 잘 부탁드립니다 🙇‍♂️

---

ConnectionPool, Transaction 학습테스트는 3단계에서 제출하겠습니다!!