### PR TITLE
[2단계 - JDBC 라이브러리 구현하기] 알파카(최휘용) 미션 제출합니다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,5 @@ tomcat.*
 tomcat.*/**
 
 **/WEB-INF/classes/**
+
+*.db

--- a/jdbc/src/main/java/com/interface21/jdbc/PreparedStatementSetter.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/PreparedStatementSetter.java
@@ -3,13 +3,7 @@ package com.interface21.jdbc;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
-public class PreparedStatementSetter {
+public interface PreparedStatementSetter {
 
-    private static final int SET_OBJECT_BASE = 1;
-
-    public void setValue(PreparedStatement psmt, Object... args) throws SQLException {
-        for (int i = 0; i < args.length; i++) {
-            psmt.setObject(i + SET_OBJECT_BASE, args[i]);
-        }
-    }
+    public void setValue(PreparedStatement psmt) throws SQLException;
 }

--- a/jdbc/src/main/java/com/interface21/jdbc/PreparedStatementSetter.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/PreparedStatementSetter.java
@@ -1,0 +1,15 @@
+package com.interface21.jdbc;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public class PreparedStatementSetter {
+
+    private static final int SET_OBJECT_BASE = 1;
+
+    public void setValue(PreparedStatement psmt, Object... args) throws SQLException {
+        for (int i = 0; i < args.length; i++) {
+            psmt.setObject(i + SET_OBJECT_BASE, args[i]);
+        }
+    }
+}

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 public class JdbcTemplate {
 
     private static final Logger log = LoggerFactory.getLogger(JdbcTemplate.class);
+    private static final int SET_OBJECT_BASE = 1;
 
     private final DataSource dataSource;
 
@@ -44,7 +45,7 @@ public class JdbcTemplate {
     private PreparedStatementSetter getPreparedStatementSetter(Object... args) {
         return statement -> {
             for (int i = 0; i < args.length; i++) {
-                statement.setObject(i + 1, args[i]);
+                statement.setObject(i + SET_OBJECT_BASE, args[i]);
             }
         };
     }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -27,11 +27,7 @@ public class JdbcTemplate {
         try (Connection conn = dataSource.getConnection();
              PreparedStatement psmt = conn.prepareStatement(sql)
         ) {
-            ResultSet rs = executeQuery(psmt, statement -> {
-                for (int i = 0; i < args.length; i++) {
-                    statement.setObject(i + 1, args[i]);
-                }
-            });
+            ResultSet rs = executeQuery(psmt, getPreparedStatementSetter(args));
 
             return mapResultSetToList(rowMapper, rs);
         } catch (SQLException e) {
@@ -43,6 +39,14 @@ public class JdbcTemplate {
             throws SQLException {
         statementSetter.setValue(psmt);
         return psmt.executeQuery();
+    }
+
+    private PreparedStatementSetter getPreparedStatementSetter(Object... args) {
+        return statement -> {
+            for (int i = 0; i < args.length; i++) {
+                statement.setObject(i + 1, args[i]);
+            }
+        };
     }
 
     private <T> List<T> mapResultSetToList(RowMapper<T> rowMapper, ResultSet rs) throws SQLException {
@@ -68,11 +72,7 @@ public class JdbcTemplate {
         try (Connection conn = dataSource.getConnection();
              PreparedStatement psmt = conn.prepareStatement(sql)
         ) {
-            return executeUpdate(psmt, statement -> {
-                for (int i = 0; i < args.length; i++) {
-                    statement.setObject(i + 1, args[i]);
-                }
-            });
+            return executeUpdate(psmt, getPreparedStatementSetter(args));
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -35,6 +35,12 @@ public class JdbcTemplate {
         }
     }
 
+    private void setPreparedStatementParameters(Object[] args, PreparedStatement psmt) throws SQLException {
+        for (int i = 0; i < args.length; i++) {
+            psmt.setObject(i + 1, args[i]);
+        }
+    }
+
     private <T> List<T> mapResultSetToList(RowMapper<T> rowMapper, ResultSet rs) throws SQLException {
         List<T> result = new ArrayList<>();
         while (rs.next()) {
@@ -42,12 +48,6 @@ public class JdbcTemplate {
             result.add(element);
         }
         return result;
-    }
-
-    private void setPreparedStatementParameters(Object[] args, PreparedStatement psmt) throws SQLException {
-        for (int i = 0; i < args.length; i++) {
-            psmt.setObject(i + 1, args[i]);
-        }
     }
 
     public <T> T queryForObject(String sql, RowMapper<T> rowMapper, Object... args) {

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -28,7 +28,7 @@ public class JdbcTemplate {
         try (Connection conn = dataSource.getConnection();
              PreparedStatement psmt = conn.prepareStatement(sql)
         ) {
-            ResultSet rs = executeQuery(psmt, getPreparedStatementSetter(args));
+            ResultSet rs = executeQuery(psmt, createArgumentPreparedStatementSetter(args));
 
             return mapResultSetToList(rowMapper, rs);
         } catch (SQLException e) {
@@ -42,7 +42,7 @@ public class JdbcTemplate {
         return psmt.executeQuery();
     }
 
-    private PreparedStatementSetter getPreparedStatementSetter(Object... args) {
+    private PreparedStatementSetter createArgumentPreparedStatementSetter(Object... args) {
         return statement -> {
             for (int i = 0; i < args.length; i++) {
                 statement.setObject(i + SET_OBJECT_BASE, args[i]);
@@ -73,7 +73,7 @@ public class JdbcTemplate {
         try (Connection conn = dataSource.getConnection();
              PreparedStatement psmt = conn.prepareStatement(sql)
         ) {
-            return executeUpdate(psmt, getPreparedStatementSetter(args));
+            return executeUpdate(psmt, createArgumentPreparedStatementSetter(args));
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -31,7 +31,7 @@ public class JdbcTemplate {
             pss.setValue(psmt);
             ResultSet rs = psmt.executeQuery();
 
-            return mapResultSetToList(rowMapper, rs);
+            return getResultsFromResultSet(rowMapper, rs);
         } catch (SQLException e) {
             throw new DataAccessException(e);
         }
@@ -49,15 +49,19 @@ public class JdbcTemplate {
         };
     }
 
-    private <T> List<T> mapResultSetToList(RowMapper<T> rowMapper, ResultSet rs) throws SQLException {
+    private <T> List<T> getResultsFromResultSet(RowMapper<T> rowMapper, ResultSet rs) throws SQLException {
         try (rs) {
-            List<T> result = new ArrayList<>();
-            while (rs.next()) {
-                T element = rowMapper.mapRow(rs, rs.getRow());
-                result.add(element);
-            }
-            return result;
+            return mapResultSetToList(rowMapper, rs);
         }
+    }
+
+    private <T> List<T> mapResultSetToList(RowMapper<T> rowMapper, ResultSet rs) throws SQLException {
+        List<T> result = new ArrayList<>();
+        while (rs.next()) {
+            T element = rowMapper.mapRow(rs, rs.getRow());
+            result.add(element);
+        }
+        return result;
     }
 
     public <T> T queryForObject(String sql, RowMapper<T> rowMapper, Object... args) {

--- a/jdbc/src/test/java/com/interface21/jdbc/core/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/com/interface21/jdbc/core/JdbcTemplateTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.interface21.dao.DataAccessException;
@@ -11,6 +12,7 @@ import com.interface21.jdbc.RowMapper;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.List;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
@@ -95,5 +97,23 @@ class JdbcTemplateTest {
         assertThatThrownBy(() -> jdbcTemplate.queryForObject("select name from users where id = ?", rowMapper, 1))
                 .isInstanceOf(DataAccessException.class)
                 .hasMessage("조회하려는 데이터가 여러 개입니다.");
+    }
+
+    @DisplayName("사용한 자원은 모두 close한다.")
+    @Test
+    public void tesa() throws SQLException {
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true, true, true, false);
+        when(resultSet.getString("name")).thenReturn("이은정", "클로버", "지니아");
+
+        RowMapper<String> rowMapper = (rs, rowNum) -> rs.getString("name");
+
+        jdbcTemplate.query("select name from users", rowMapper);
+
+        assertAll(
+                () -> verify(connection).close(),
+                () -> verify(preparedStatement).close(),
+                () -> verify(resultSet).close()
+        );
     }
 }

--- a/jdbc/src/test/java/com/interface21/jdbc/core/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/com/interface21/jdbc/core/JdbcTemplateTest.java
@@ -101,7 +101,7 @@ class JdbcTemplateTest {
 
     @DisplayName("사용한 자원은 모두 close한다.")
     @Test
-    public void tesa() throws SQLException {
+    public void closeAllResources() throws SQLException {
         when(preparedStatement.executeQuery()).thenReturn(resultSet);
         when(resultSet.next()).thenReturn(true, true, true, false);
         when(resultSet.getString("name")).thenReturn("이은정", "클로버", "지니아");

--- a/study/src/test/java/transaction/stage2/Stage2Test.java
+++ b/study/src/test/java/transaction/stage2/Stage2Test.java
@@ -36,8 +36,8 @@ class Stage2Test {
     }
 
     /**
-     * 생성된 트랜잭션이 몇 개인가?
-     * 왜 그런 결과가 나왔을까?
+     * 생성된 트랜잭션이 몇 개인가? 1개
+     * 왜 그런 결과가 나왔을까? Second는 외부 트랜잭션인 First에 참여하게 된다.
      */
     @Test
     void testRequired() {
@@ -50,8 +50,8 @@ class Stage2Test {
     }
 
     /**
-     * 생성된 트랜잭션이 몇 개인가?
-     * 왜 그런 결과가 나왔을까?
+     * 생성된 트랜잭션이 몇 개인가? 2
+     * 왜 그런 결과가 나왔을까? REQUIRES_NEW는 외부 트랜잭션이 있어도 새로운 트랜잭션을 만든다.
      */
     @Test
     void testRequiredNew() {
@@ -67,6 +67,8 @@ class Stage2Test {
     /**
      * firstUserService.saveAndExceptionWithRequiredNew()에서 강제로 예외를 발생시킨다.
      * REQUIRES_NEW 일 때 예외로 인한 롤백이 발생하면서 어떤 상황이 발생하는 지 확인해보자.
+     *
+     * 외부 트랜잭션이 예외를 터뜨려도 내부 트랜잭션은 롤백되지 않는다.
      */
     @Test
     void testRequiredNewWithRollback() {
@@ -81,6 +83,11 @@ class Stage2Test {
     /**
      * FirstUserService.saveFirstTransactionWithSupports() 메서드를 보면 @Transactional이 주석으로 되어 있다.
      * 주석인 상태에서 테스트를 실행했을 때와 주석을 해제하고 테스트를 실행했을 때 어떤 차이점이 있는지 확인해보자.
+     *
+     * SUPPORTS는 트랜잭션이 존재할 경우에만 참여하고 그렇지 않을 경우 트랜잭션을 생성하지 않는다.
+     * 하지만 주석 처리 후 확인해보면 실제로는 트랜잭션 매니저가 Second를 처리하기 위해 논리 트랜잭션을 생성한다.
+     * 물리 트랜잭션: 하나의 커넥션으로 처리하는 실제 트랜잭션
+     * 논리 트랜잭션: 스프링이 처리하는 트랜잭션 영역
      */
     @Test
     void testSupports() {
@@ -96,6 +103,8 @@ class Stage2Test {
      * FirstUserService.saveFirstTransactionWithMandatory() 메서드를 보면 @Transactional이 주석으로 되어 있다.
      * 주석인 상태에서 테스트를 실행했을 때와 주석을 해제하고 테스트를 실행했을 때 어떤 차이점이 있는지 확인해보자.
      * SUPPORTS와 어떤 점이 다른지도 같이 챙겨보자.
+     *
+     * SUPPORTS와 전부 동일하지만 외부 트랜잭션이 존재하지 않을 경우 예외를 터뜨린다.
      */
     @Test
     void testMandatory() {
@@ -113,6 +122,10 @@ class Stage2Test {
      * 다시 테스트를 실행하면 몇 개의 물리적 트랜잭션이 동작할까?
      *
      * 스프링 공식 문서에서 물리적 트랜잭션과 논리적 트랜잭션의 차이점이 무엇인지 찾아보자.
+     * -> 위에 작성
+     *
+     * NOT_SUPPORTED는 외부 트랜잭션이 존재할 경우 그 트랜잭션과 별개로 트랜잭션 없이 진행한다.
+     * 존재하지 않을 경우에는 트랜잭션 없이 진행한다.
      */
     @Test
     void testNotSupported() {
@@ -128,6 +141,14 @@ class Stage2Test {
     /**
      * 아래 테스트는 왜 실패할까?
      * FirstUserService.saveFirstTransactionWithNested() 메서드의 @Transactional을 주석 처리하면 어떻게 될까?
+     *
+     * NESTED는 외부 트랜잭션이 존재할 경우 중첩 트랜잭션을 생성한다. 존재하지 않으면 트랜잭션을 생서한다.
+     * 중첩 트랜잭션의 동작은 다음과 같다
+     * 외부 트랜잭션 예외 -> 외부와 내부 둘다 롤백
+     * 내부 트랜잭션 예외 -> 내부만 롤백
+     * 내부는 외부에 영향을 받지만 내부는 외부에 영향을 받지 않는다.
+     * NESTED는 jdbc의 savepoint 기능을 사용하는데 DB 드라이버가 이를 지원하지 않을 경우 사용이 불가능하다.(JPA도)
+     * NESTED를 통해 중첩 트랜잭션을 생성하려고 하면 예외가 발생한다.
      */
     @Test
     void testNested() {
@@ -141,6 +162,8 @@ class Stage2Test {
 
     /**
      * 마찬가지로 @Transactional을 주석처리하면서 관찰해보자.
+     *
+     * NEVER는 외부 트랜잭션이 존재할 경우 예외를 발생한다. 존재하지 않을 경우 트랜잭션 없이 진행한다.
      */
     @Test
     void testNever() {


### PR DESCRIPTION
안녕하세요 클로버 🍀 
이번 미션의 요구사항은 어쩌다 보니 이전 미션에서 많이 고민했던 부분이라 어느 정도 반영이 되어 있었어서 크게 변경점은 없습니다.

추가된 부분이 적어서 정리해보자면 크게
1. 학습 테스트 주석 추가
2. `ResultSet`을 close하도록 코드 수정 및 테스트 추가
3. 쿼리에 argument 넣어주는 로직 인터페이스로 분리

이렇게 되는데요.

3번은 미션 요구사항을 참고해서 적용하게 되었습니다.
근데 이 부분을 **인터페이스와 람다함수**로 리팩토링하게 되면서 여러 고민을 하게 되었고, 이에 따라 현재와 같은 구조가 되었습니다.
이전의 구조처럼 가변인자로 `args`를 받고 내부적으로 정의된 `PreparedStatementSetter`의 로직에 따라서만 동작하게 된다면 인터페이스와 람다함수의 장점을 전혀 살리지 못할 뿐더러 이전 구조보다 더 깔끔하지 못하다는 생각이 들어서 어떻게 해야 장점을 살릴 수 있을까 생각을 좀 해봤습니다.

그래서 현재는 `PreparedStatementSetter`를 매개변수로 받는 `update`와 `query` 메서드가 기본적으로 존재하고, 다른 매개변수를 받아야 하는 다른 메서드들에서는 해당 메서드를 호출하는 체이닝 방식으로 구현을 하게 되었습니다.
가변인자인 `args`를 받게 되면 내부적으로 정의된 `PreparedStatementSetter`를 사용해서 다른 메서드를 호출하게 되고, `PreparedStatementSetter`를 매개변수로 받는 메서드도 public으로 열어놓음으로써 외부에서도 직접 인터페이스를 정의해 사용할 수 있도록 했습니다.
물론 지금 당장 전부 활용되고 있진 않지만 이전 구조에 비해 유연성과 확장성이 조금 더 개선되었다고 느껴져서 일단 이렇게 구현하게 되었습니다.
제 이런 고민과 현재 구조에 대해 클로버가 어떻게 생각하는지(+ 클롱바는 어떤 식으로 리팩토링을 진행했는지) 궁금해서 주저리주저리 설명하게 되었는데 쓸데 없이 긴 글 읽으시느라 수고 많으셨습니다..
이번 리뷰도 잘 부탁드려요! 🙇 