### PR TITLE
[JDBC 라이브러리 구현하기 - 2단계] 아토(이혜린) 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -2,7 +2,6 @@ package com.techcourse.dao;
 
 import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.domain.User;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 

--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -19,49 +19,30 @@ public class UserDao {
     public void insert(final User user) {
         final var sql = "insert into users (account, password, email) values (?, ?, ?)";
 
-        List<Object> paramList = new ArrayList<>();
-        paramList.add(user.getAccount());
-        paramList.add(user.getPassword());
-        paramList.add(user.getEmail());
-
-        jdbcTemplate.executeQuery(sql, paramList);
+        jdbcTemplate.executeQuery(sql, user.getAccount(), user.getPassword(), user.getEmail());
     }
 
     public void update(final User user) {
         final var sql = "update users set account = ?, password = ?, email = ? where id = ?";
 
-        List<Object> paramList = new ArrayList<>();
-        paramList.add(user.getAccount());
-        paramList.add(user.getPassword());
-        paramList.add(user.getEmail());
-        paramList.add(user.getId());
-
-        jdbcTemplate.executeQuery(sql, paramList);
+        jdbcTemplate.executeQuery(sql, user.getAccount(), user.getPassword(), user.getEmail(), user.getId());
     }
 
     public List<User> findAll() {
         final var sql = "select id, account, password, email from users";
 
-        List<Object> paramList = new ArrayList<>();
-
-        return jdbcTemplate.executeQueryForObjects(sql, paramList, maker);
+        return jdbcTemplate.executeQueryForObjects(sql, maker);
     }
 
     public Optional<User> findById(final Long id) {
         final var sql = "select id, account, password, email from users where id = ?";
 
-        List<Object> paramList = new ArrayList<>();
-        paramList.add(id);
-
-        return jdbcTemplate.executeQueryForObject(sql, paramList, maker);
+        return jdbcTemplate.executeQueryForObject(sql, maker, id);
     }
 
     public Optional<User> findByAccount(final String account) {
         final var sql = "select id, account, password, email from users where account = ?";
 
-        List<Object> paramList = new ArrayList<>();
-        paramList.add(account);
-
-        return jdbcTemplate.executeQueryForObject(sql, paramList, maker);
+        return jdbcTemplate.executeQueryForObject(sql, maker, account);
     }
 }

--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -4,6 +4,7 @@ import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.domain.User;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class UserDao {
 
@@ -46,7 +47,7 @@ public class UserDao {
         return jdbcTemplate.executeQueryForObjects(sql, paramList, maker);
     }
 
-    public User findById(final Long id) {
+    public Optional<User> findById(final Long id) {
         final var sql = "select id, account, password, email from users where id = ?";
 
         List<Object> paramList = new ArrayList<>();
@@ -55,7 +56,7 @@ public class UserDao {
         return jdbcTemplate.executeQueryForObject(sql, paramList, maker);
     }
 
-    public User findByAccount(final String account) {
+    public Optional<User> findByAccount(final String account) {
         final var sql = "select id, account, password, email from users where account = ?";
 
         List<Object> paramList = new ArrayList<>();

--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -1,62 +1,29 @@
 package com.techcourse.dao;
 
-import com.techcourse.domain.UserHistory;
 import com.interface21.jdbc.core.JdbcTemplate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
+import com.techcourse.domain.UserHistory;
+import java.util.ArrayList;
+import java.util.List;
 
 public class UserHistoryDao {
 
-    private static final Logger log = LoggerFactory.getLogger(UserHistoryDao.class);
-
-    private final DataSource dataSource;
-
-    public UserHistoryDao(final DataSource dataSource) {
-        this.dataSource = dataSource;
-    }
+    private final JdbcTemplate jdbcTemplate;
 
     public UserHistoryDao(final JdbcTemplate jdbcTemplate) {
-        this.dataSource = null;
+        this.jdbcTemplate = jdbcTemplate;
     }
 
     public void log(final UserHistory userHistory) {
         final var sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
 
-        Connection conn = null;
-        PreparedStatement pstmt = null;
-        try {
-            conn = dataSource.getConnection();
-            pstmt = conn.prepareStatement(sql);
+        List<Object> paramList = new ArrayList<>();
+        paramList.add(userHistory.getUserId());
+        paramList.add(userHistory.getAccount());
+        paramList.add(userHistory.getPassword());
+        paramList.add(userHistory.getEmail());
+        paramList.add(userHistory.getCreatedAt());
+        paramList.add(userHistory.getCreateBy());
 
-            log.debug("query : {}", sql);
-
-            pstmt.setLong(1, userHistory.getUserId());
-            pstmt.setString(2, userHistory.getAccount());
-            pstmt.setString(3, userHistory.getPassword());
-            pstmt.setString(4, userHistory.getEmail());
-            pstmt.setObject(5, userHistory.getCreatedAt());
-            pstmt.setString(6, userHistory.getCreateBy());
-            pstmt.executeUpdate();
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
-        } finally {
-            try {
-                if (pstmt != null) {
-                    pstmt.close();
-                }
-            } catch (SQLException ignored) {}
-
-            try {
-                if (conn != null) {
-                    conn.close();
-                }
-            } catch (SQLException ignored) {}
-        }
+        jdbcTemplate.executeQuery(sql, paramList);
     }
 }

--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -2,8 +2,6 @@ package com.techcourse.dao;
 
 import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.domain.UserHistory;
-import java.util.ArrayList;
-import java.util.List;
 
 public class UserHistoryDao {
 

--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -16,14 +16,7 @@ public class UserHistoryDao {
     public void log(final UserHistory userHistory) {
         final var sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
 
-        List<Object> paramList = new ArrayList<>();
-        paramList.add(userHistory.getUserId());
-        paramList.add(userHistory.getAccount());
-        paramList.add(userHistory.getPassword());
-        paramList.add(userHistory.getEmail());
-        paramList.add(userHistory.getCreatedAt());
-        paramList.add(userHistory.getCreateBy());
-
-        jdbcTemplate.executeQuery(sql, paramList);
+        jdbcTemplate.executeQuery(sql, userHistory.getUserId(), userHistory.getAccount(), userHistory.getPassword(),
+                userHistory.getEmail(), userHistory.getCreatedAt(), userHistory.getCreateBy());
     }
 }

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -16,7 +16,8 @@ public class UserService {
     }
 
     public User findById(final long id) {
-        return userDao.findById(id);
+        return userDao.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
     }
 
     public void insert(final User user) {

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -6,6 +6,9 @@ import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -19,52 +22,80 @@ class UserDaoTest {
 
         JdbcTemplate jdbcTemplate = new JdbcTemplate(DataSourceConfig.getInstance());
         userDao = new UserDao(jdbcTemplate);
-        final var user = new User("gugu", "password", "hkkang@woowahan.com");
+        final User user = new User("gugu", "password", "hkkang@woowahan.com");
         userDao.insert(user);
+    }
+
+    @AfterEach
+    void tearDown() {
+        try (var connection = DataSourceConfig.getInstance().getConnection();
+             var statement = connection.createStatement()) {
+            statement.execute("DELETE FROM USERS");
+            statement.execute("ALTER TABLE USERS ALTER COLUMN id RESTART WITH 1");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Test
     void findAll() {
-        final var users = userDao.findAll();
+        final List<User> users = userDao.findAll();
+
+        System.out.println(users.size());
 
         assertThat(users).isNotEmpty();
     }
 
     @Test
     void findById() {
-        final var user = userDao.findById(1L);
+        final User user = userDao.findById(1L).orElseThrow();
 
         assertThat(user.getAccount()).isEqualTo("gugu");
     }
 
     @Test
+    void findByIdWhenNotExist() {
+        final Optional<User> user = userDao.findById(1000L);
+
+        assertThat(user.isEmpty()).isTrue();
+    }
+
+    @Test
     void findByAccount() {
-        final var account = "gugu";
-        final var user = userDao.findByAccount(account);
+        final String account = "gugu";
+        final User user = userDao.findByAccount(account).orElseThrow();
 
         assertThat(user.getAccount()).isEqualTo(account);
     }
 
     @Test
+    void findByAccountWhenNotExist() {
+        final String account = "notExist";
+        final Optional<User> user = userDao.findByAccount(account);
+
+        assertThat(user.isEmpty()).isTrue();
+    }
+
+    @Test
     void insert() {
-        final var account = "insert-gugu";
-        final var user = new User(account, "password", "hkkang@woowahan.com");
+        final String account = "insert-gugu";
+        final User user = new User(account, "password", "hkkang@woowahan.com");
         userDao.insert(user);
 
-        final var actual = userDao.findById(2L);
+        final User actual = userDao.findById(2L).orElseThrow();
 
         assertThat(actual.getAccount()).isEqualTo(account);
     }
 
     @Test
     void update() {
-        final var newPassword = "password99";
-        final var user = userDao.findById(1L);
+        final String newPassword = "password99";
+        final User user = userDao.findById(1L).orElseThrow();
         user.changePassword(newPassword);
 
         userDao.update(user);
 
-        final var actual = userDao.findById(1L);
+        final User actual = userDao.findById(1L).orElseThrow();
 
         assertThat(actual.getPassword()).isEqualTo(newPassword);
     }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 public class JdbcTemplate {
 
     private static final Logger log = LoggerFactory.getLogger(JdbcTemplate.class);
+    private static final int SQL_PARAMETER_INDEX_OFFSET = 1;
 
     private final DataSource dataSource;
 
@@ -22,13 +23,13 @@ public class JdbcTemplate {
         this.dataSource = dataSource;
     }
 
-    public void executeQuery(String sql, List<Object> paramList) {
+    public void executeQuery(String sql, Object... params) {
         try (Connection connection = dataSource.getConnection();
              PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
 
             log.debug("query : {}", sql);
 
-            setParams(paramList, preparedStatement);
+            setParams(preparedStatement, params);
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
@@ -36,11 +37,11 @@ public class JdbcTemplate {
         }
     }
 
-    public <T> Optional<T> executeQueryForObject(String sql, List<Object> paramList, ObjectMaker<T> maker) {
+    public <T> Optional<T> executeQueryForObject(String sql, ObjectMaker<T> maker, Object... params) {
         try (Connection connection = dataSource.getConnection();
              PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
 
-            setParams(paramList, preparedStatement);
+            setParams(preparedStatement, params);
             ResultSet resultSet = preparedStatement.executeQuery();
 
             log.debug("query : {}", sql);
@@ -61,11 +62,11 @@ public class JdbcTemplate {
         }
     }
 
-    public <T> List<T> executeQueryForObjects(String sql, List<Object> paramList, ObjectMaker<T> maker) {
+    public <T> List<T> executeQueryForObjects(String sql, ObjectMaker<T> maker, Object... params) {
         try (Connection connection = dataSource.getConnection();
              PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
 
-            setParams(paramList, preparedStatement);
+            setParams(preparedStatement, params);
             ResultSet resultSet = preparedStatement.executeQuery();
 
             log.debug("query : {}", sql);
@@ -82,9 +83,9 @@ public class JdbcTemplate {
         }
     }
 
-    private void setParams(List<Object> paramList, PreparedStatement preparedStatement) throws SQLException {
-        for (int index = 1; index <= paramList.size(); index++) {
-            preparedStatement.setObject(index, paramList.get(index - 1));
+    private void setParams(PreparedStatement preparedStatement, Object... params) throws SQLException {
+        for (int index = 0; index < params.length; index++) {
+            preparedStatement.setObject(index + SQL_PARAMETER_INDEX_OFFSET, params[index]);
         }
     }
 }

--- a/jdbc/src/test/java/com/interface21/jdbc/core/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/com/interface21/jdbc/core/JdbcTemplateTest.java
@@ -1,6 +1,7 @@
 package com.interface21.jdbc.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -62,15 +63,32 @@ class JdbcTemplateTest {
         List<Object> paramList = List.of(1L);
         ObjectMaker<TestObject> maker = new TestMaker();
 
-        when(resultSet.next()).thenReturn(true);
+        when(resultSet.next()).thenReturn(true, false);
         when(resultSet.getString(1)).thenReturn("atto");
         when(resultSet.getString(2)).thenReturn("jeje");
         when(resultSet.getString(3)).thenReturn("daon");
 
-        TestObject actual = jdbcTemplate.executeQueryForObject(sql, paramList, maker);
+        TestObject actual = jdbcTemplate.executeQueryForObject(sql, paramList, maker).orElseThrow();
         TestObject expected = new TestObject("atto", "jeje", "daon");
 
         assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("하나의 객체를 만들 때 결과물이 두개 이상이면 예외가 발생한다.")
+    void executeQueryForObjectWithDuplicate() throws SQLException {
+        String sql = "select name, reviewer, reviewee from crew where id = ?";
+        List<Object> paramList = List.of(1L);
+        ObjectMaker<TestObject> maker = new TestMaker();
+
+        when(resultSet.next()).thenReturn(true, true);
+        when(resultSet.getString(1)).thenReturn("atto", "jeje");
+        when(resultSet.getString(2)).thenReturn("jeje", "rush");
+        when(resultSet.getString(3)).thenReturn("daon", "atto");
+
+        assertThatThrownBy(() -> jdbcTemplate.executeQueryForObject(sql, paramList, maker))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("결과가 두개 이상 존재합니다.");
     }
 
     @Test

--- a/jdbc/src/test/java/com/interface21/jdbc/core/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/com/interface21/jdbc/core/JdbcTemplateTest.java
@@ -43,9 +43,8 @@ class JdbcTemplateTest {
     @DisplayName("업데이트문이 실행된다.")
     void executeQuery() {
         String sql = "INSERT INTO crew (name, reviewer, reviewee) VALUES (?, ?, ?)";
-        List<Object> paramList = List.of("atto", "jeje", "daon");
 
-        jdbcTemplate.executeQuery(sql, paramList);
+        jdbcTemplate.executeQuery(sql, "atto", "jeje", "daon");
 
         assertAll(
                 () -> verify(preparedStatement, times(1)).setObject(1, "atto"),
@@ -60,7 +59,6 @@ class JdbcTemplateTest {
     @DisplayName("하나의 객체를 만든다.")
     void executeQueryForObject() throws SQLException {
         String sql = "select name, reviewer, reviewee from crew where id = ?";
-        List<Object> paramList = List.of(1L);
         ObjectMaker<TestObject> maker = new TestMaker();
 
         when(resultSet.next()).thenReturn(true, false);
@@ -68,7 +66,7 @@ class JdbcTemplateTest {
         when(resultSet.getString(2)).thenReturn("jeje");
         when(resultSet.getString(3)).thenReturn("daon");
 
-        TestObject actual = jdbcTemplate.executeQueryForObject(sql, paramList, maker).orElseThrow();
+        TestObject actual = jdbcTemplate.executeQueryForObject(sql, maker, 1L).orElseThrow();
         TestObject expected = new TestObject("atto", "jeje", "daon");
 
         assertThat(actual).isEqualTo(expected);
@@ -78,7 +76,6 @@ class JdbcTemplateTest {
     @DisplayName("하나의 객체를 만들 때 결과물이 두개 이상이면 예외가 발생한다.")
     void executeQueryForObjectWithDuplicate() throws SQLException {
         String sql = "select name, reviewer, reviewee from crew where id = ?";
-        List<Object> paramList = List.of(1L);
         ObjectMaker<TestObject> maker = new TestMaker();
 
         when(resultSet.next()).thenReturn(true, true);
@@ -86,7 +83,7 @@ class JdbcTemplateTest {
         when(resultSet.getString(2)).thenReturn("jeje", "rush");
         when(resultSet.getString(3)).thenReturn("daon", "atto");
 
-        assertThatThrownBy(() -> jdbcTemplate.executeQueryForObject(sql, paramList, maker))
+        assertThatThrownBy(() -> jdbcTemplate.executeQueryForObject(sql, maker, 1L))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("결과가 두개 이상 존재합니다.");
     }
@@ -95,7 +92,6 @@ class JdbcTemplateTest {
     @DisplayName("객체의 리스트를 만든다.")
     void executeQueryForObjects() throws SQLException {
         String sql = "select name, reviewer, reviewee from crew";
-        List<Object> paramList = List.of(1L);
         ObjectMaker<TestObject> maker = new TestMaker();
 
         when(resultSet.next()).thenReturn(true, false);
@@ -103,7 +99,7 @@ class JdbcTemplateTest {
         when(resultSet.getString(2)).thenReturn("jeje");
         when(resultSet.getString(3)).thenReturn("daon");
 
-        List<TestObject> actual = jdbcTemplate.executeQueryForObjects(sql, paramList, maker);
+        List<TestObject> actual = jdbcTemplate.executeQueryForObjects(sql, maker);
         List<TestObject> expected = List.of(new TestObject("atto", "jeje", "daon"));
 
         assertThat(actual).isEqualTo(expected);

--- a/study/src/main/resources/schema.sql
+++ b/study/src/main/resources/schema.sql
@@ -1,5 +1,6 @@
-# mysql 8.0.30부터는 statement.execute()으로 여러 쿼리를 한 번에 실행할 수 없다.
-# 멀티 쿼리 옵션을 url로 전달하도록 수정하는 방법을 찾아서 적용하자.
+-- mysql 8.0.30부터는 statement.execute()으로 여러 쿼리를 한 번에 실행할 수 없다.
+-- 멀티 쿼리 옵션을 url로 전달하도록 수정하는 방법을 찾아서 적용하자.
+
 CREATE TABLE IF NOT EXISTS users (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     account VARCHAR(100) NOT NULL,

--- a/study/src/test/java/connectionpool/stage1/Stage1Test.java
+++ b/study/src/test/java/connectionpool/stage1/Stage1Test.java
@@ -54,6 +54,7 @@ class Stage1Test {
      *
      * HikariCP의 pool size는 몇으로 설정하는게 좋을까?
      * https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
+     * 운 나쁘면 데드락이 생길 수 있는 최대 커넥션의 수(스레드 수 * (필요한 커넥션 수 - 1)) + 1 !!
      *
      * HikariCP를 사용할 때 적용하면 좋은 MySQL 설정
      * https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration

--- a/study/src/test/java/transaction/stage1/Stage1Test.java
+++ b/study/src/test/java/transaction/stage1/Stage1Test.java
@@ -2,6 +2,7 @@ package transaction.stage1;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import java.util.List;
 import org.h2.jdbcx.JdbcDataSource;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -34,10 +35,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *   Read phenomena | Dirty reads | Non-repeatable reads | Phantom reads
  * Isolation level  |             |                      |
  * -----------------|-------------|----------------------|--------------
- * Read Uncommitted |             |                      |
- * Read Committed   |             |                      |
- * Repeatable Read  |             |                      |
- * Serializable     |             |                      |
+ * Read Uncommitted |      +      |           +          |      +
+ * Read Committed   |      -      |           +          |      +
+ * Repeatable Read  |      -      |           -          |      +
+ * Serializable     |      -      |           -          |      -
  */
 class Stage1Test {
 
@@ -58,10 +59,10 @@ class Stage1Test {
      *   Read phenomena | Dirty reads
      * Isolation level  |
      * -----------------|-------------
-     * Read Uncommitted |
-     * Read Committed   |
-     * Repeatable Read  |
-     * Serializable     |
+     * Read Uncommitted |    +
+     * Read Committed   |    -
+     * Repeatable Read  |    -
+     * Serializable     |    -
      */
     @Test
     void dirtyReading() throws SQLException {
@@ -81,7 +82,7 @@ class Stage1Test {
             final var subConnection = dataSource.getConnection();
 
             // 적절한 격리 레벨을 찾는다.
-            final int isolationLevel = Connection.TRANSACTION_NONE;
+            final int isolationLevel = Connection.TRANSACTION_READ_COMMITTED;
 
             // 트랜잭션 격리 레벨을 설정한다.
             subConnection.setTransactionIsolation(isolationLevel);
@@ -111,10 +112,10 @@ class Stage1Test {
      *   Read phenomena | Non-repeatable reads
      * Isolation level  |
      * -----------------|---------------------
-     * Read Uncommitted |
-     * Read Committed   |
-     * Repeatable Read  |
-     * Serializable     |
+     * Read Uncommitted |    +
+     * Read Committed   |    +
+     * Repeatable Read  |    -
+     * Serializable     |    -
      */
     @Test
     void noneRepeatable() throws SQLException {
@@ -130,7 +131,7 @@ class Stage1Test {
         connection.setAutoCommit(false);
 
         // 적절한 격리 레벨을 찾는다.
-        final int isolationLevel = Connection.TRANSACTION_NONE;
+        final int isolationLevel = Connection.TRANSACTION_REPEATABLE_READ;
 
         // 트랜잭션 격리 레벨을 설정한다.
         connection.setTransactionIsolation(isolationLevel);
@@ -173,17 +174,18 @@ class Stage1Test {
      *   Read phenomena | Phantom reads
      * Isolation level  |
      * -----------------|--------------
-     * Read Uncommitted |
-     * Read Committed   |
-     * Repeatable Read  |
-     * Serializable     |
+     * Read Uncommitted |    +
+     * Read Committed   |    +
+     * Repeatable Read  |    +
+     * Serializable     |    -
      */
     @Test
     void phantomReading() throws SQLException {
 
         // testcontainer로 docker를 실행해서 mysql에 연결한다.
         final var mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.0.30"))
-                .withLogConsumer(new Slf4jLogConsumer(log));
+                .withLogConsumer(new Slf4jLogConsumer(log))
+                .withInitScript("schema.sql");
         mysql.start();
         setUp(createMySQLDataSource(mysql));
 
@@ -197,13 +199,13 @@ class Stage1Test {
         connection.setAutoCommit(false);
 
         // 적절한 격리 레벨을 찾는다.
-        final int isolationLevel = Connection.TRANSACTION_NONE;
+        final int isolationLevel = Connection.TRANSACTION_SERIALIZABLE;
 
         // 트랜잭션 격리 레벨을 설정한다.
         connection.setTransactionIsolation(isolationLevel);
 
         // 사용자A가 id로 범위를 조회했다.
-        userDao.findGreaterThan(connection, 1);
+        final List<User> expected = userDao.findGreaterThan(connection, 1);
 
         new Thread(RunnableWrapper.accept(() -> {
             // 사용자B가 새로 연결하여
@@ -226,12 +228,12 @@ class Stage1Test {
         userDao.updatePasswordGreaterThan(connection, "qqqq", 1);
 
         // 사용자A가 다시 id로 범위를 조회했다.
-        final var actual = userDao.findGreaterThan(connection, 1);
+        final List<User> actual = userDao.findGreaterThan(connection, 1);
 
         // 트랜잭션 격리 레벨에 따라 아래 테스트가 통과한다.
         // 각 격리 레벨은 어떤 결과가 나오는지 직접 확인해보자.
         log.info("isolation level : {}, user : {}", isolationLevel, actual);
-        assertThat(actual).hasSize(1);
+        assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
 
         connection.rollback();
         mysql.close();

--- a/study/src/test/java/transaction/stage1/User.java
+++ b/study/src/test/java/transaction/stage1/User.java
@@ -1,5 +1,7 @@
 package transaction.stage1;
 
+import java.util.Objects;
+
 public class User {
 
     private Long id;
@@ -52,5 +54,22 @@ public class User {
                 ", email='" + email + '\'' +
                 ", password='" + password + '\'' +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        User user = (User) o;
+        return Objects.equals(id, user.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/study/src/test/java/transaction/stage2/FirstUserService.java
+++ b/study/src/test/java/transaction/stage2/FirstUserService.java
@@ -77,7 +77,7 @@ public class FirstUserService {
         return of(firstTransactionName, secondTransactionName);
     }
 
-//    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithMandatory() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());
@@ -99,7 +99,7 @@ public class FirstUserService {
         return of(firstTransactionName, secondTransactionName);
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
+//    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithNested() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());
@@ -110,7 +110,7 @@ public class FirstUserService {
         return of(firstTransactionName, secondTransactionName);
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
+//    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithNever() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());

--- a/study/src/test/java/transaction/stage2/User.java
+++ b/study/src/test/java/transaction/stage2/User.java
@@ -1,9 +1,9 @@
 package transaction.stage2;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 
 @Entity(name = "users")
 public class User {


### PR DESCRIPTION
제제 안녕하세요! 또다시 아토입니다.

저번 피드백에서 `PreparedStatement` 값 세팅 관련해 이야기해주셨는데,
일단은 lms를 참고해 가변인자를 사용하도록 변경해보았습니다!

또한 객체 하나를 만들어야 하는데 두개 이상 나올 경우에 대한 예외를 처리해주었고,
없을 경우 바로 null을 리턴하는 것이 아닌 Optional.empty()를 리턴하도록 변경했습니다.

그리고 람다를 사용하려 했는데...
`preparedStatement`의 `executeUpdate()` 와 `executeQuery()` 때문에
공통되는 부분들을 분리하면 람다 안에서 또 try-catch를 사용해야 하더라고요.

```java
public void executeQuery(String sql, Object... params) {
    execute(sql, params, preparedStatement -> {
        try {
            preparedStatement.executeUpdate();
            return null;
        } catch (SQLException e) {
            throw new RuntimeException(e);
        }
    });
}

private <T> T execute(String sql, Object[] params, Function<PreparedStatement, T> action) {
    try (Connection connection = dataSource.getConnection();
        PreparedStatement preparedStatement = connection.prepareStatement(sql)) {

        setParams(preparedStatement, params);
        log.debug("query : {}", sql);

        return action.apply(preparedStatement);

    } catch (SQLException e) {
        log.error(e.getMessage(), e);
        throw new DataAccessException("SQL 실행 중 오류가 발생했습니다.", e);
    }
}
```

어차피 같은 SQLException을 잡을텐데, try-catch를 두 번으로 분리할 필요가 있나 싶어 일단 람다 적용은 하지 않았습니다.
혹시 다른 방안이 있을까요?
아니면 두 번으로 분리하더라도 코드 중복을 줄일 수 있으니 람다를 적용하는 게 더 낫다고 생각하시나요??

이번에도 편하게 리뷰 주세요! 감사합니다.