### PR TITLE
[2단계 - JDBC 라이브러리 구현하기] 레모네(이지현) 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class UserDao {
 
-    private static final RowMapper<User> ROW_MAPPER = (rs, rowNum) -> new User(
+    private static final RowMapper<User> ROW_MAPPER = rs -> new User(
             rs.getLong("id"),
             rs.getString("account"),
             rs.getString("password"),

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -4,7 +4,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.sql.DataSource;
@@ -25,71 +24,38 @@ public class JdbcTemplate {
     }
 
     public void update(final String sql, final Object... args) {
-        try (final Connection connection = dataSource.getConnection();
-             final PreparedStatement statement = connection.prepareStatement(sql)) {
-            setStatement(statement, args);
+        execute(sql, args, statement -> {
             log.info("update query : {}", sql);
-            statement.executeUpdate();
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new DataAccessException(e);
-        }
+            return statement.executeUpdate();
+        });
     }
 
     public <T> T queryForObject(final String sql, final RowMapper<T> rowMapper, final Object... args) {
-        try (final Connection connection = dataSource.getConnection();
-             final PreparedStatement statement = connection.prepareStatement(sql)) {
-            setStatement(statement, args);
+        return execute(sql, args, statement -> {
             log.info("select query : {}", sql);
             final ResultSet resultSet = statement.executeQuery();
-            final List<T> data = extractData(resultSet, rowMapper, args);
+            final List<T> data = PreparedStatementUtils.extractData(resultSet, rowMapper, args);
             return result(data);
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new DataAccessException(e);
-        }
-    }
-
-    public <T> List<T> query(final String sql, final RowMapper<T> rowMapper) {
-        try (final Connection connection = dataSource.getConnection();
-             final PreparedStatement statement = connection.prepareStatement(sql)) {
-            log.info("select query : {}", sql);
-            final ResultSet resultSet = statement.executeQuery();
-            return extractData(resultSet, rowMapper);
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new DataAccessException(e);
-        }
+        });
     }
 
     public <T> List<T> query(final String sql, final RowMapper<T> rowMapper, final Object... args) {
+        return execute(sql, args, statement -> {
+            final ResultSet resultSet = statement.executeQuery();
+            log.info("select query : {}", sql);
+            return PreparedStatementUtils.extractData(resultSet, rowMapper);
+        });
+    }
+
+    private <T> T execute(final String sql, final Object[] args, final QueryExecutor<T> executor) {
         try (final Connection connection = dataSource.getConnection();
              final PreparedStatement statement = connection.prepareStatement(sql)) {
-            setStatement(statement, args);
-            log.info("select query : {}", sql);
-            final ResultSet resultSet = statement.executeQuery();
-            return extractData(resultSet, rowMapper);
+            PreparedStatementUtils.setParameter(statement, args);
+            return executor.execute(statement);
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
             throw new DataAccessException(e);
         }
-    }
-
-    private void setStatement(PreparedStatement statement, final Object... args)
-            throws SQLException {
-        int index = 1;
-        for (final Object arg : args) {
-            statement.setObject(index++, arg);
-        }
-    }
-
-    private <T> List<T> extractData(final ResultSet resultSet, final RowMapper<T> rowMapper, final Object... args)
-            throws SQLException {
-        final List<T> results = new ArrayList<>();
-        while (resultSet.next()) {
-            results.add(rowMapper.mapRow(resultSet, args.length));
-        }
-        return results;
     }
 
     private <T> T result(final List<T> data) throws SQLException {

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -34,7 +34,7 @@ public class JdbcTemplate {
         return execute(sql, args, statement -> {
             log.info("select query : {}", sql);
             final ResultSet resultSet = statement.executeQuery();
-            final List<T> data = PreparedStatementUtils.extractData(resultSet, rowMapper, args);
+            final List<T> data = PreparedStatementUtils.extractData(resultSet, rowMapper);
             return result(data);
         });
     }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/PreparedStatementUtils.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/PreparedStatementUtils.java
@@ -16,11 +16,11 @@ public class PreparedStatementUtils {
         }
     }
 
-    public static <T> List<T> extractData(final ResultSet resultSet, final RowMapper<T> rowMapper, final Object... args)
+    public static <T> List<T> extractData(final ResultSet resultSet, final RowMapper<T> rowMapper)
             throws SQLException {
         final List<T> results = new ArrayList<>();
         while (resultSet.next()) {
-            results.add(rowMapper.mapRow(resultSet, args.length));
+            results.add(rowMapper.mapRow(resultSet));
         }
         return results;
     }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/PreparedStatementUtils.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/PreparedStatementUtils.java
@@ -1,0 +1,27 @@
+package com.interface21.jdbc.core;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PreparedStatementUtils {
+
+    public static void setParameter(PreparedStatement statement, final Object... args)
+            throws SQLException {
+        int index = 1;
+        for (final Object arg : args) {
+            statement.setObject(index++, arg);
+        }
+    }
+
+    public static <T> List<T> extractData(final ResultSet resultSet, final RowMapper<T> rowMapper, final Object... args)
+            throws SQLException {
+        final List<T> results = new ArrayList<>();
+        while (resultSet.next()) {
+            results.add(rowMapper.mapRow(resultSet, args.length));
+        }
+        return results;
+    }
+}

--- a/jdbc/src/main/java/com/interface21/jdbc/core/QueryExecutor.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/QueryExecutor.java
@@ -1,0 +1,10 @@
+package com.interface21.jdbc.core;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface QueryExecutor<T> {
+
+    T execute(PreparedStatement preparedStatement) throws SQLException;
+}

--- a/jdbc/src/main/java/com/interface21/jdbc/core/RowMapper.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/RowMapper.java
@@ -5,5 +5,5 @@ import java.sql.SQLException;
 
 public interface RowMapper<T> {
 
-    T mapRow(final ResultSet rs, final int rowNum) throws SQLException;
+    T mapRow(final ResultSet rs) throws SQLException;
 }

--- a/jdbc/src/test/java/com/interface21/jdbc/core/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/com/interface21/jdbc/core/JdbcTemplateTest.java
@@ -22,7 +22,7 @@ import com.techcourse.domain.User;
 
 class JdbcTemplateTest {
 
-    private static final RowMapper<User> ROW_MAPPER = (rs, rowNum) -> new User(
+    private static final RowMapper<User> ROW_MAPPER = rs -> new User(
             rs.getLong("id"),
             rs.getString("account"),
             rs.getString("password"),

--- a/study/src/main/resources/schema.sql
+++ b/study/src/main/resources/schema.sql
@@ -1,5 +1,5 @@
-# mysql 8.0.30부터는 statement.execute()으로 여러 쿼리를 한 번에 실행할 수 없다.
-# 멀티 쿼리 옵션을 url로 전달하도록 수정하는 방법을 찾아서 적용하자.
+-- mysql 8.0.30부터는 statement.execute()으로 여러 쿼리를 한 번에 실행할 수 없다.
+-- 멀티 쿼리 옵션을 url로 전달하도록 수정하는 방법을 찾아서 적용하자.
 CREATE TABLE IF NOT EXISTS users (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     account VARCHAR(100) NOT NULL,

--- a/study/src/test/java/transaction/stage2/FirstUserService.java
+++ b/study/src/test/java/transaction/stage2/FirstUserService.java
@@ -77,7 +77,7 @@ public class FirstUserService {
         return of(firstTransactionName, secondTransactionName);
     }
 
-//    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithMandatory() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());
@@ -99,7 +99,7 @@ public class FirstUserService {
         return of(firstTransactionName, secondTransactionName);
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
+//    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithNested() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());
@@ -110,7 +110,7 @@ public class FirstUserService {
         return of(firstTransactionName, secondTransactionName);
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
+//    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithNever() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());

--- a/study/src/test/java/transaction/stage2/Stage2Test.java
+++ b/study/src/test/java/transaction/stage2/Stage2Test.java
@@ -1,14 +1,16 @@
 package transaction.stage2;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * 트랜잭션 전파(Transaction Propagation)란?
@@ -36,74 +38,102 @@ class Stage2Test {
     }
 
     /**
-     * 생성된 트랜잭션이 몇 개인가?
+     * 생성된 트랜잭션이 몇 개인가? 1개
      * 왜 그런 결과가 나왔을까?
+     * Propagation.REQUIRED 트랜잭션 안에 Propagation.REQUIRED 가 있다.
+     * REQUIRED 특성상 첫번째 트랜잭션이 존재하기 때문에 두번째 트랜잭션은 첫번째 트랜잭션을 사용한다.
      */
     @Test
     void testRequired() {
-        final var actual = firstUserService.saveFirstTransactionWithRequired();
+        final List<String> actual = firstUserService.saveFirstTransactionWithRequired()
+                .stream()
+                .toList();
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(1)
+                .containsExactly(actual.get(0));
     }
 
     /**
-     * 생성된 트랜잭션이 몇 개인가?
+     * 생성된 트랜잭션이 몇 개인가? 2개
      * 왜 그런 결과가 나왔을까?
+     * Propagation.REQUIRED 트랜잭션 안에 Propagation.REQUIRES_NEW 가 있다.
+     * REQUIRES_NEW 는 트랜잭션이 이미 존재해도 새로운 트랜잭션을 생성하기 때문에 총 2개가 생성된다.
      */
     @Test
     void testRequiredNew() {
-        final var actual = firstUserService.saveFirstTransactionWithRequiredNew();
+        final List<String> actual = firstUserService.saveFirstTransactionWithRequiredNew()
+                .stream()
+                .toList();
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(2)
+                .containsExactly(actual.get(0), actual.get(1));
     }
 
     /**
      * firstUserService.saveAndExceptionWithRequiredNew()에서 강제로 예외를 발생시킨다.
      * REQUIRES_NEW 일 때 예외로 인한 롤백이 발생하면서 어떤 상황이 발생하는 지 확인해보자.
+     * REQUIRES_NEW 때문에 두개의 트랜잭션이 생기는데,
+     * 첫번째 트랜잭션 안에 있는 두번째 트랜잭션은 성공적으로 커밋된다.
+     * 두번째 트랜잭션이 커밋된 뒤 첫번째 트랜잭션에서 에러가 발생하기 때문에 첫번째 트랜잭션은 롤백된다.
+     * 그래서 결국 하나의 데이터만 저장된다.
      */
     @Test
     void testRequiredNewWithRollback() {
-        assertThat(firstUserService.findAll()).hasSize(-1);
+        assertThat(firstUserService.findAll()).hasSize(0);
 
         assertThatThrownBy(() -> firstUserService.saveAndExceptionWithRequiredNew())
                 .isInstanceOf(RuntimeException.class);
 
-        assertThat(firstUserService.findAll()).hasSize(-1);
+        assertThat(firstUserService.findAll()).hasSize(1);
     }
 
     /**
      * FirstUserService.saveFirstTransactionWithSupports() 메서드를 보면 @Transactional이 주석으로 되어 있다.
      * 주석인 상태에서 테스트를 실행했을 때와 주석을 해제하고 테스트를 실행했을 때 어떤 차이점이 있는지 확인해보자.
+     * 주석일 때:
+     * 트랜잭션이 없기 때문에 REQUIRED 속성에 따라 트랜잭션이 하나 생성되고,
+     * 그 안에 있는 메서드는 SUPPORTS 속성이므로 이미 생성된 트랜잭션을 사용한다.
+     * 그래서 size는 1이고, 첫번째 트랜잭션만 포함되어 있는 것을 알 수 있다.
+     * 주석이 아닐 때:
+     * 부모 트랜잭션을 사용한다. 따라서 총 1개의 트랜잭션이 생성된다.
      */
     @Test
     void testSupports() {
-        final var actual = firstUserService.saveFirstTransactionWithSupports();
+        final List<String> actual = firstUserService.saveFirstTransactionWithSupports()
+                .stream()
+                .toList();
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(1)
+                .containsExactly(actual.get(0));
     }
 
     /**
      * FirstUserService.saveFirstTransactionWithMandatory() 메서드를 보면 @Transactional이 주석으로 되어 있다.
      * 주석인 상태에서 테스트를 실행했을 때와 주석을 해제하고 테스트를 실행했을 때 어떤 차이점이 있는지 확인해보자.
      * SUPPORTS와 어떤 점이 다른지도 같이 챙겨보자.
+     * 주석일 때:
+     * 트랜잭션이 없기 때문에 MANDATORY 속성에 따라 예외가 발생한다.
+     * - No existing transaction found for transaction marked with propagation 'mandatory'
+     * 주석이 아닐 때:
+     * REQUIRED 에 따라 트랜잭션이 생성되고, MANDATORY 속성에 따라 이미 생성된 트랜잭션을 사용한다.
+     * 총 1개의 트랜잭션이 생성된다.
      */
     @Test
     void testMandatory() {
-        final var actual = firstUserService.saveFirstTransactionWithMandatory();
+        final List<String> actual = firstUserService.saveFirstTransactionWithMandatory()
+                .stream()
+                .toList();
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(1)
+                .containsExactly(actual.get(0));
     }
 
     /**
@@ -112,41 +142,59 @@ class Stage2Test {
      * 다시 테스트를 실행하면 몇 개의 물리적 트랜잭션이 동작할까?
      *
      * 스프링 공식 문서에서 물리적 트랜잭션과 논리적 트랜잭션의 차이점이 무엇인지 찾아보자.
+     * NOT_SUPPORTED
+     * : 부모 트랜잭션이 존재할 경우, 부모 트랜잭션에서 동작하는 태스크는 트랜잭션이 적용되지만,
+     *   NOT_SUPPORTED 설정이 된 트랜잭션 안에서는 동작하지 않는다.
+     * : 부모 트랜잭션이 유무에 상관없이 명시적으로 트랜잭션이 생성되지만 트랜잭션은 동작하지 않는다.
+     * 주석일 때: 트랜잭션 총 1개
+     * 주석 아닐 때: 트랜잭션 총 2개
      */
     @Test
     void testNotSupported() {
-        final var actual = firstUserService.saveFirstTransactionWithNotSupported();
+        final List<String> actual = firstUserService.saveFirstTransactionWithNotSupported()
+                .stream()
+                .toList();
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(2)
+                .containsExactly(actual.get(0), actual.get(1));
     }
 
     /**
      * 아래 테스트는 왜 실패할까?
      * FirstUserService.saveFirstTransactionWithNested() 메서드의 @Transactional을 주석 처리하면 어떻게 될까?
+     * NESTED : 부모 트랜잭션이 있으면 중첩 트랜잭션을 만들고, 없으면 새로운 자식 트랜잭션을 만든다.
+     * 부모 트랜잭션은 자식 트랜잭션에게 영향을 미치지만, 자식 트랜잭션은 부모 트랜잭션에게 영향을 미치지 않는다.
+     * 그래서 자식 트랜잭션이 실패하면 부모 트랜잭션은 롤백되지 않는다.
+     * jpa는 NESTED를 지원하지 않기 때문에 JpaDialect does not support savepoints - check your JPA provider's capabilities 예외가 발생한다.
      */
     @Test
     void testNested() {
-        final var actual = firstUserService.saveFirstTransactionWithNested();
+        final List<String> actual = firstUserService.saveFirstTransactionWithNested()
+                .stream()
+                .toList();
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(1)
+                .containsExactly(actual.get(0));
     }
 
     /**
      * 마찬가지로 @Transactional을 주석처리하면서 관찰해보자.
+     * NEVER: 트랜잭션이 명시적으로 표현은 되지만 트랜잭션을 사용하지 않는다. 부모 트랜잭션이 존재할 경우 예외가 발생한다.
+     * IllegalTransactionStateException: Existing transaction found for transaction marked with propagation 'never'
      */
     @Test
     void testNever() {
-        final var actual = firstUserService.saveFirstTransactionWithNever();
+        final List<String> actual = firstUserService.saveFirstTransactionWithNever()
+                .stream()
+                .toList();
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(1)
+                .containsExactly(actual.get(0));
     }
 }

--- a/study/src/test/java/transaction/stage2/User.java
+++ b/study/src/test/java/transaction/stage2/User.java
@@ -1,9 +1,9 @@
 package transaction.stage2;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 
 @Entity(name = "users")
 public class User {


### PR DESCRIPTION
안녕하세요 로빈!! 
2단계 pr이 조금 늦어졌네요🥲 2단계 리뷰도 잘 부탁드립니다!

아래는 1단계에서 남겨주신 피드백에 대한 답변입니다.

---
> 가변인자가 포함되지 않은 메서드가 필요할까요? 가변인자의 동작 방식에대해 조금 더 학습해보시고 다음 단계에서 학습 내용을 반영해보면 좋을 것 같아요.

로빈의 피드백을 보고 가변인자가 없는 메서드를 지워주었는데, 컴파일 에러가 발생하지 않더라구요.
그래서 가변인자에 대해 찾아보았는데, 인자를 **0개 이상** 전달할 수 있다고 합니다!
인자가 없을 경우도 허용하기 때문에 가변인자가 포함되지 않은 메서드는 삭제해 주었습니다.
로빈이 가변인자의 동작 방식에 대해 강조하신 이유를 이제 알았네요😀

> setObject 를 이용하면 모든 상황에서 안전하게 지정할 수 있을까요? 다음 두 가지 상황은 항상 동일하게 동작하나요?
statement.setInt(1, 1);
statement.setObject(1, 1);

제가 찾아본 결과 jdbc 드라이버에 따라 다르다고 합니다!
MySQL의 경우 특정 데이터 타입을 setObject로 받으면, 자동으로 해당 데이터 타입으로 변환해 준다고 합니다.
[스택오버플로우](https://stackoverflow.com/questions/35531621/can-preparedstatements-setobject-method-be-used-for-any-datatype)
[mysql connector의 PreparedStatement 구현체](https://github.com/spullara/mysql-connector-java/blob/master/src/main/java/com/mysql/jdbc/PreparedStatement.java)
모든 상황에서 안전하게 지정하려면 위의 구현체처럼 `setObject`를 구체적인 데이터 타입으로 변환하는 메서드가 필요할 것 같네요!

> 다음 단계에서 필요하지 않다면 (mapRow 메서드의 rowNum 인자를)제거하는 방향으로 가면 좋을 것 같아요. 😄

제거해 주었습니다!

> 다음 단계에서 반복적인 try-catch 구조를 제거해볼 방법을 생각해보면 좋을 것 같아요~

함수형 인터페이스를 사용해서 중복 로직을 생략해 주었습니다!