### PR TITLE
[2단계 - 리팩터링] 짱수(장혁수) 미션 제출합니다.

### DIFF
--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -1,5 +1,6 @@
 package com.techcourse.dao;
 
+import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
@@ -16,7 +17,7 @@ class UserDaoTest {
     void setup() {
         DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
 
-        userDao = new UserDao(DataSourceConfig.getInstance());
+        userDao = new UserDao(new JdbcTemplate(DataSourceConfig.getInstance()));
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
         userDao.insert(user);
     }

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -1,13 +1,15 @@
 package com.techcourse.dao;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.interface21.dao.NoResultFoundException;
 import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class UserDaoTest {
 
@@ -19,13 +21,18 @@ class UserDaoTest {
 
         userDao = new UserDao(new JdbcTemplate(DataSourceConfig.getInstance()));
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
-        userDao.insert(user);
+
+        try {
+            userDao.findByAccount("gugu");
+        } catch (NoResultFoundException e) {
+            userDao.insert(user);
+        }
     }
 
     @Test
     void findAll() {
         final var users = userDao.findAll();
-
+        users.forEach(System.out::println);
         assertThat(users).isNotEmpty();
     }
 

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -50,9 +50,9 @@ public class JdbcTemplate {
 
             ResultSet resultSet = pstmt.executeQuery();
 
-            validateSingleResult(resultSet);
             if (resultSet.next()) {
                 T result = objectMapper.map(resultSet, resultSet.getRow());
+                validateNoRemainResult(resultSet);
                 return result;
             }
 
@@ -63,12 +63,10 @@ public class JdbcTemplate {
         }
     }
 
-    private void validateSingleResult(ResultSet resultSet) throws SQLException {
-        resultSet.last();
-        if (resultSet.getRow() > 1) {
+    private void validateNoRemainResult(ResultSet resultSet) throws SQLException {
+        if (resultSet.next()) {
             throw new NotSingleResultException();
         }
-        resultSet.beforeFirst();
     }
 
     public <T> List<T> getResults(String query, ObjectMapper<T> objectMapper, Object... parameters) {

--- a/jdbc/src/test/java/com/interface21/jdbc/core/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/com/interface21/jdbc/core/JdbcTemplateTest.java
@@ -1,6 +1,5 @@
 package com.interface21.jdbc.core;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -43,7 +42,7 @@ class JdbcTemplateTest {
         void notSingleResultTest() throws SQLException {
             ResultSet resultSet = mock(ResultSet.class);
             when(preparedStatement.executeQuery()).thenReturn(resultSet);
-            when(resultSet.getRow()).thenReturn(2);
+            when(resultSet.next()).thenReturn(true).thenReturn(true);
 
             assertThatThrownBy(() -> jdbcTemplate.getResult("query", (rs, rowNum) -> new Object()))
                     .isInstanceOf(NotSingleResultException.class);

--- a/study/src/main/resources/schema.sql
+++ b/study/src/main/resources/schema.sql
@@ -1,5 +1,5 @@
-# mysql 8.0.30부터는 statement.execute()으로 여러 쿼리를 한 번에 실행할 수 없다.
-# 멀티 쿼리 옵션을 url로 전달하도록 수정하는 방법을 찾아서 적용하자.
+-- mysql 8.0.30부터는 statement.execute()으로 여러 쿼리를 한 번에 실행할 수 없다.
+-- 멀티 쿼리 옵션을 url로 전달하도록 수정하는 방법을 찾아서 적용하자.
 CREATE TABLE IF NOT EXISTS users (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     account VARCHAR(100) NOT NULL,

--- a/study/src/test/java/connectionpool/stage1/Stage1Test.java
+++ b/study/src/test/java/connectionpool/stage1/Stage1Test.java
@@ -9,6 +9,8 @@ import java.sql.SQLException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import javax.sql.DataSource;
+
 class Stage1Test {
 
     private static final String H2_URL = "jdbc:h2:./test;DB_CLOSE_DELAY=-1";
@@ -28,16 +30,21 @@ class Stage1Test {
      */
     @Test
     void testJdbcConnectionPool() throws SQLException {
-        final JdbcConnectionPool jdbcConnectionPool = JdbcConnectionPool.create(H2_URL, USER, PASSWORD);
+        final DataSource jdbcConnectionPool = JdbcConnectionPool.create(H2_URL, USER, PASSWORD);
+        /*
+        이건 h2 의 클래스.
+        ConnectionPool 에 대한 인터페이스라던지 그런건 없을까?
+        -> ConnectionPool 역시 getConnection 으로 `Connection` 을 얻어오기 위한 객체라서 `DataSource` 로 추상화해서 사용해도 될 것 같음
+         */
 
-        assertThat(jdbcConnectionPool.getActiveConnections()).isZero();
+        assertThat(((JdbcConnectionPool) jdbcConnectionPool).getActiveConnections()).isZero();
         try (final var connection = jdbcConnectionPool.getConnection()) {
             assertThat(connection.isValid(1)).isTrue();
-            assertThat(jdbcConnectionPool.getActiveConnections()).isEqualTo(1);
+            assertThat(((JdbcConnectionPool) jdbcConnectionPool).getActiveConnections()).isEqualTo(1);
         }
-        assertThat(jdbcConnectionPool.getActiveConnections()).isZero();
+        assertThat(((JdbcConnectionPool) jdbcConnectionPool).getActiveConnections()).isZero();
 
-        jdbcConnectionPool.dispose();
+        ((JdbcConnectionPool) jdbcConnectionPool).dispose();
     }
 
     /**
@@ -54,20 +61,26 @@ class Stage1Test {
      *
      * HikariCP의 pool size는 몇으로 설정하는게 좋을까?
      * https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
+     * -> 코어 개수보다 스레드 개수가 더 많으면 타임 슬라이싱을 통해 스레드를 지원한다. 때문에 외려 더 느려질 수 있다. + alpha
      *
      * HikariCP를 사용할 때 적용하면 좋은 MySQL 설정
      * https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration
      */
     @Test
     void testHikariCP() {
-        final var hikariConfig = new HikariConfig();
+        /*final var hikariConfig = new HikariConfig();
+        //essential
         hikariConfig.setJdbcUrl(H2_URL);
         hikariConfig.setUsername(USER);
         hikariConfig.setPassword(PASSWORD);
-        hikariConfig.setMaximumPoolSize(5);
         hikariConfig.addDataSourceProperty("cachePrepStmts", "true");
         hikariConfig.addDataSourceProperty("prepStmtCacheSize", "250");
         hikariConfig.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
+        hikariConfig.addDataSourceProperty("useServerPrepStmts", "true");
+        hikariConfig.setMaximumPoolSize(5);
+        -> Config 파일을 properties 로 관리해 어플리케이션 코드의 변경을 방지할 수 있다.
+        */
+        final var hikariConfig = new HikariConfig("/Users/mac/Desktop/zangsu/wooteco/Level4/java-jdbc/study/src/test/java/connectionpool/stage1/hikari.properties");
 
         final var dataSource = new HikariDataSource(hikariConfig);
         final var properties = dataSource.getDataSourceProperties();
@@ -76,6 +89,7 @@ class Stage1Test {
         assertThat(properties.getProperty("cachePrepStmts")).isEqualTo("true");
         assertThat(properties.getProperty("prepStmtCacheSize")).isEqualTo("250");
         assertThat(properties.getProperty("prepStmtCacheSqlLimit")).isEqualTo("2048");
+        assertThat(properties.getProperty("useServerPrepStmts")).isEqualTo("true");
 
         dataSource.close();
     }

--- a/study/src/test/java/connectionpool/stage1/hikari.properties
+++ b/study/src/test/java/connectionpool/stage1/hikari.properties
@@ -1,0 +1,9 @@
+jdbcUrl=jdbc:h2:./test;DB_CLOSE_DELAY=-1
+username=sa
+password=
+
+maximumPoolSize=5
+dataSource.cachePrepStmts=true
+dataSource.prepStmtCacheSize=250
+dataSource.prepStmtCacheSqlLimit=2048
+dataSource.useServerPrepStmts=true

--- a/study/src/test/java/transaction/stage1/Stage1Test.java
+++ b/study/src/test/java/transaction/stage1/Stage1Test.java
@@ -140,9 +140,9 @@ class Stage1Test {
         // 적절한 격리 레벨을 찾는다.
         final int isolationLevel =
 //                    Connection.TRANSACTION_NONE;
-                Connection.TRANSACTION_READ_UNCOMMITTED;
+//                Connection.TRANSACTION_READ_UNCOMMITTED;
 //                    Connection.TRANSACTION_READ_COMMITTED;
-//                    Connection.TRANSACTION_REPEATABLE_READ;
+                    Connection.TRANSACTION_REPEATABLE_READ;
 //                    Connection.TRANSACTION_SERIALIZABLE;
 
         // 트랜잭션 격리 레벨을 설정한다.

--- a/study/src/test/java/transaction/stage1/Stage1Test.java
+++ b/study/src/test/java/transaction/stage1/Stage1Test.java
@@ -1,7 +1,13 @@
 package transaction.stage1;
 
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.TimeUnit;
+
+import javax.sql.DataSource;
+
 import org.h2.jdbcx.JdbcDataSource;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -10,15 +16,12 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.utility.DockerImageName;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
 import transaction.DatabasePopulatorUtils;
 import transaction.RunnableWrapper;
-
-import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.concurrent.TimeUnit;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * 격리 레벨(Isolation Level)에 따라 여러 사용자가 동시에 db에 접근했을 때 어떤 문제가 발생하는지 확인해보자.
@@ -58,10 +61,10 @@ class Stage1Test {
      *   Read phenomena | Dirty reads
      * Isolation level  |
      * -----------------|-------------
-     * Read Uncommitted |
-     * Read Committed   |
-     * Repeatable Read  |
-     * Serializable     |
+     * Read Uncommitted |   +
+     * Read Committed   |   -
+     * Repeatable Read  |   -
+     * Serializable     |   -
      */
     @Test
     void dirtyReading() throws SQLException {
@@ -81,7 +84,12 @@ class Stage1Test {
             final var subConnection = dataSource.getConnection();
 
             // 적절한 격리 레벨을 찾는다.
-            final int isolationLevel = Connection.TRANSACTION_NONE;
+            final int isolationLevel =
+//                    Connection.TRANSACTION_NONE;
+//                    Connection.TRANSACTION_READ_UNCOMMITTED;
+//                    Connection.TRANSACTION_READ_COMMITTED;
+//                    Connection.TRANSACTION_REPEATABLE_READ;
+                    Connection.TRANSACTION_SERIALIZABLE;
 
             // 트랜잭션 격리 레벨을 설정한다.
             subConnection.setTransactionIsolation(isolationLevel);
@@ -111,10 +119,10 @@ class Stage1Test {
      *   Read phenomena | Non-repeatable reads
      * Isolation level  |
      * -----------------|---------------------
-     * Read Uncommitted |
-     * Read Committed   |
-     * Repeatable Read  |
-     * Serializable     |
+     * Read Uncommitted |         +
+     * Read Committed   |         +
+     * Repeatable Read  |         -
+     * Serializable     |         -
      */
     @Test
     void noneRepeatable() throws SQLException {
@@ -130,7 +138,12 @@ class Stage1Test {
         connection.setAutoCommit(false);
 
         // 적절한 격리 레벨을 찾는다.
-        final int isolationLevel = Connection.TRANSACTION_NONE;
+        final int isolationLevel =
+//                    Connection.TRANSACTION_NONE;
+                Connection.TRANSACTION_READ_UNCOMMITTED;
+//                    Connection.TRANSACTION_READ_COMMITTED;
+//                    Connection.TRANSACTION_REPEATABLE_READ;
+//                    Connection.TRANSACTION_SERIALIZABLE;
 
         // 트랜잭션 격리 레벨을 설정한다.
         connection.setTransactionIsolation(isolationLevel);
@@ -173,10 +186,10 @@ class Stage1Test {
      *   Read phenomena | Phantom reads
      * Isolation level  |
      * -----------------|--------------
-     * Read Uncommitted |
-     * Read Committed   |
-     * Repeatable Read  |
-     * Serializable     |
+     * Read Uncommitted |      +
+     * Read Committed   |      +
+     * Repeatable Read  |      +
+     * Serializable     |      -
      */
     @Test
     void phantomReading() throws SQLException {
@@ -197,7 +210,12 @@ class Stage1Test {
         connection.setAutoCommit(false);
 
         // 적절한 격리 레벨을 찾는다.
-        final int isolationLevel = Connection.TRANSACTION_NONE;
+        final int isolationLevel =
+//                    Connection.TRANSACTION_NONE;
+//                Connection.TRANSACTION_READ_UNCOMMITTED;
+//                    Connection.TRANSACTION_READ_COMMITTED;
+//                    Connection.TRANSACTION_REPEATABLE_READ;
+                Connection.TRANSACTION_SERIALIZABLE;
 
         // 트랜잭션 격리 레벨을 설정한다.
         connection.setTransactionIsolation(isolationLevel);
@@ -239,7 +257,7 @@ class Stage1Test {
 
     private static DataSource createMySQLDataSource(final JdbcDatabaseContainer<?> container) {
         final var config = new HikariConfig();
-        config.setJdbcUrl(container.getJdbcUrl());
+        config.setJdbcUrl(container.getJdbcUrl() + "?allowMultiQueries=true");
         config.setUsername(container.getUsername());
         config.setPassword(container.getPassword());
         config.setDriverClassName(container.getDriverClassName());

--- a/study/src/test/java/transaction/stage2/FirstUserService.java
+++ b/study/src/test/java/transaction/stage2/FirstUserService.java
@@ -77,7 +77,7 @@ public class FirstUserService {
         return of(firstTransactionName, secondTransactionName);
     }
 
-//    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithMandatory() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());
@@ -99,7 +99,7 @@ public class FirstUserService {
         return of(firstTransactionName, secondTransactionName);
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
+//    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithNested() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());
@@ -110,7 +110,7 @@ public class FirstUserService {
         return of(firstTransactionName, secondTransactionName);
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
+//    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithNever() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());

--- a/study/src/test/java/transaction/stage2/Stage2Test.java
+++ b/study/src/test/java/transaction/stage2/Stage2Test.java
@@ -1,14 +1,14 @@
 package transaction.stage2;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * 트랜잭션 전파(Transaction Propagation)란?
@@ -25,7 +25,7 @@ class Stage2Test {
     private static final Logger log = LoggerFactory.getLogger(Stage2Test.class);
 
     @Autowired
-    private FirstUserService firstUserService;
+    public FirstUserService firstUserService;
 
     @Autowired
     private UserRepository userRepository;
@@ -36,8 +36,15 @@ class Stage2Test {
     }
 
     /**
-     * 생성된 트랜잭션이 몇 개인가?
+     * 생성된 트랜잭션이 몇 개인가? 1개
      * 왜 그런 결과가 나왔을까?
+     * PROPAGATION_REQUIRED 는 트랜잭션이 없다면 새로운 트랜잭션을 생성하고,
+     * 이미 트랜잭션이 존재한다면 해당 트랜잭션에 참여한다.
+     *
+     * note:
+     * 기본적으로 참여하는 트랜잭션은 로컬 격리 수준, 시간 초과 값 또는 읽기 전용 플래그(있는 경우)를 무시하고 외부 범위의 특성에 합류합니다.
+     * 라고 함
+     * 아마 외부 트랜잭션에 참여할 땐 지금 메서드의 설정값들을 무시한다는 이야기인 것 같음
      */
     @Test
     void testRequired() {
@@ -45,13 +52,15 @@ class Stage2Test {
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(1)
+                .containsExactly("transaction.stage2.FirstUserService.saveFirstTransactionWithRequired");
     }
 
     /**
-     * 생성된 트랜잭션이 몇 개인가?
+     * 생성된 트랜잭션이 몇 개인가? 2
      * 왜 그런 결과가 나왔을까?
+     * PROPAGATION_REQUIRES_NEW 는 항상 독립적인 트랜잭션을 생성
+     *  절대 외부 트랜잭션에 참여하지 않음
      */
     @Test
     void testRequiredNew() {
@@ -59,27 +68,40 @@ class Stage2Test {
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(2)
+                .containsExactlyInAnyOrder(
+                        "transaction.stage2.SecondUserService.saveSecondTransactionWithRequiresNew",
+                        "transaction.stage2.FirstUserService.saveFirstTransactionWithRequiredNew"
+                )
+        ;
     }
 
     /**
      * firstUserService.saveAndExceptionWithRequiredNew()에서 강제로 예외를 발생시킨다.
      * REQUIRES_NEW 일 때 예외로 인한 롤백이 발생하면서 어떤 상황이 발생하는 지 확인해보자.
+     *
+     * -> REQUIRES_NEW 는 물리적 트랜잭션을 새로 만든다.
+     *  second 의 트랜잭션이 커밋된 이후 first 의 트랜잭션이 롤백 되기 때문에 second 의 트랜잭션을 롤백시키지 않는다.
      */
     @Test
     void testRequiredNewWithRollback() {
-        assertThat(firstUserService.findAll()).hasSize(-1);
+        assertThat(firstUserService.findAll()).hasSize(0);
 
         assertThatThrownBy(() -> firstUserService.saveAndExceptionWithRequiredNew())
                 .isInstanceOf(RuntimeException.class);
 
-        assertThat(firstUserService.findAll()).hasSize(-1);
+        assertThat(firstUserService.findAll()).hasSize(1);
     }
 
     /**
      * FirstUserService.saveFirstTransactionWithSupports() 메서드를 보면 @Transactional이 주석으로 되어 있다.
      * 주석인 상태에서 테스트를 실행했을 때와 주석을 해제하고 테스트를 실행했을 때 어떤 차이점이 있는지 확인해보자.
+     *
+     * 주석: 물리적 트랜잭션 0개
+     *
+     * 주석 해제: 물리적 트랜잭션 1개
+     *
+     * Supports 는 트랜잭션이 있으면 해당 트랜잭션을 이용 / 트랜잭션이 없으면 비트랜잭션으로 실행
      */
     @Test
     void testSupports() {
@@ -87,14 +109,23 @@ class Stage2Test {
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(1)
+                .containsExactly(
+//                        "transaction.stage2.FirstUserService.saveFirstTransactionWithSupports"
+                        "transaction.stage2.SecondUserService.saveSecondTransactionWithSupports"
+                );
     }
 
     /**
      * FirstUserService.saveFirstTransactionWithMandatory() 메서드를 보면 @Transactional이 주석으로 되어 있다.
      * 주석인 상태에서 테스트를 실행했을 때와 주석을 해제하고 테스트를 실행했을 때 어떤 차이점이 있는지 확인해보자.
      * SUPPORTS와 어떤 점이 다른지도 같이 챙겨보자.
+     *
+     * 주석: 예외!!
+     *
+     * 주석 해제: 물리적 트랜잭션 1개
+     *
+     * Supports 는 트랜잭션이 있으면 해당 트랜잭션을 이용 / 트랜잭션이 없으면 예외 발생
      */
     @Test
     void testMandatory() {
@@ -102,8 +133,11 @@ class Stage2Test {
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(1)
+                .containsExactly(
+//                        "transaction.stage2.SecondUserService.saveSecondTransactionWithMandatory"
+                        "transaction.stage2.FirstUserService.saveFirstTransactionWithMandatory"
+                );
     }
 
     /**
@@ -111,7 +145,15 @@ class Stage2Test {
      * FirstUserService.saveFirstTransactionWithNotSupported() 메서드의 @Transactional을 주석 처리하자.
      * 다시 테스트를 실행하면 몇 개의 물리적 트랜잭션이 동작할까?
      *
+     * 주석: 0
+     *
+     * 주석 해제: 1
+     *
      * 스프링 공식 문서에서 물리적 트랜잭션과 논리적 트랜잭션의 차이점이 무엇인지 찾아보자.
+     * -> 논리적 트랜잭션은 Spring 에서 지원하는 하나의 Transaction 범위
+     * -> 물리적 트랜잭션은 실제 DB 에서 지원하는 Transaction 범위
+     *
+     * NOT_SUPPORTED 는 먼저 존재하는 트랜잭션이 있다면 일시 중단한 다음 트랜잭션 없이 비즈니스 로직이 실행된다.
      */
     @Test
     void testNotSupported() {
@@ -119,13 +161,23 @@ class Stage2Test {
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(2)
+                .containsExactlyInAnyOrder(
+                        "transaction.stage2.FirstUserService.saveFirstTransactionWithNotSupported",
+                        "transaction.stage2.SecondUserService.saveSecondTransactionWithNotSupported"
+                );
     }
 
     /**
      * 아래 테스트는 왜 실패할까?
      * FirstUserService.saveFirstTransactionWithNested() 메서드의 @Transactional을 주석 처리하면 어떻게 될까?
+     *
+     * NESTED 는 기존 트랜잭션이 있다면 저장 지점을 표시한다.
+     *  예외가가 발생하면 해당 저장 지점으로 롤백된다.
+     *  기존 트랜잭션이 있었지만, 저장 지점이 없어서 문제가 되었다.
+     * 기존 트랜잭션이 없으면 REQUIRED 처럼 동작한다.
+     * https://docs.spring.io/spring-framework/reference/data-access/transaction/declarative/tx-propagation
+     * .html#tx-propagation-nested
      */
     @Test
     void testNested() {
@@ -133,12 +185,13 @@ class Stage2Test {
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(1)
+                .containsExactly("transaction.stage2.SecondUserService.saveSecondTransactionWithNested");
     }
 
     /**
      * 마찬가지로 @Transactional을 주석처리하면서 관찰해보자.
+     * -> Never 은 활성 트랜잭션이 있으면 예외를 던진다.
      */
     @Test
     void testNever() {
@@ -146,7 +199,9 @@ class Stage2Test {
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(1)
+                .containsExactly(
+                        "transaction.stage2.SecondUserService.saveSecondTransactionWithNever"
+                );
     }
 }

--- a/study/src/test/java/transaction/stage2/User.java
+++ b/study/src/test/java/transaction/stage2/User.java
@@ -1,9 +1,9 @@
 package transaction.stage2;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 
 @Entity(name = "users")
 public class User {


### PR DESCRIPTION
안녕하세요 이든!
2단계는 리팩토링이었는데요. 

이미 1단계 코드에서 제가 생각할 수 있는 최선의 리팩토링을 적용한 채로 코드를 제출했다 보니 어떤 것을 해야할지 생각이 나지 않았어요.
아래는 제가 롤백한 시도들입니다.

1. `PreparedStatementSetter`
가이드에 제공된 것 처럼 `PreparedStatementSetter` 를 분리해 볼까 했었는데, 해당 책임이 클래스로 분리될 이유를 찾지 못했어요.
이 기능을 다르게 변경하여 사용하는 시나리오도 머릿속에 떠오르는 상황이 없었고요.
이정도로 작고 현재 클래스와 강결합된 역할이라면 `private` 메서드로 유지하는 것이 오히려 옳은 선택이라 생각했습니다.

2. 데코레이터 패턴 
다음으로 고려했던 것은 비즈니스 코드 분리를 위한 추상클래스 도입이었어요.
이 경우 사실상 중복코드 제거가 불가능하고, 관심사의 분리를 위한 작업이 되었어요.
추상 클래스의 메서드에서 `try-catch` 부분을 구현한 뒤 `internalXXX` 메서드로 포워딩 하는 방식이었는데요.

해당 작업에서 관심사 분리를 할 수 있었지만, 추상화를 위한 추상 클래스 사용이 아니었기 때문에 굉장히 어색해 반영하지 않았어요.

3. 메서드 템플릿 패턴
위와 동일한 이유로 템플릿 메서드 패턴을 고려하기도 하였습니다.
그러나 조회와 생성/수정에 대해 필요한 파라미터 타입이 조금씩 다르더라고요.
조회시에는 `ObjectMapper` 클래스로 `ResultSet` -> 객체 변환이 필요하지만 수정시엔 해당 작업이 필요가 없었어요.
이런 상황에서 함수형 인터페이스를 사용한 템플릿 메서드 패턴 사용이 힘들었습니다.

---

이러한 이유로 결국 학습테스트 추가 이외에는 변경된 부분이 없네요..
그래도 더 고민하기보단 이든의 의견을 들어보는 것이 좋을 것 같아 PR 제출합니다!