### PR TITLE
[4단계 - JDBC 라이브러리 구현하기] 로빈(임수빈) 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -3,7 +3,6 @@ package com.techcourse.dao;
 import com.interface21.jdbc.core.JdbcTemplate;
 import com.interface21.jdbc.core.ResultSetParser;
 import com.techcourse.domain.User;
-import java.sql.Connection;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,29 +24,29 @@ public class UserDao {
         this.jdbcTemplate = jdbcTemplate;
     }
 
-    public void insert(Connection connection, final User user) {
+    public void insert(final User user) {
         final var sql = "insert into users (account, password, email) values (?, ?, ?)";
-        jdbcTemplate.queryAndGetUpdateRowsCount(connection, sql, user.getAccount(), user.getPassword(), user.getEmail());
+        jdbcTemplate.queryAndGetUpdateRowsCount(sql, user.getAccount(), user.getPassword(), user.getEmail());
     }
 
-    public void update(Connection connection, final User user) {
+    public void update(final User user) {
         final var sql = "update users set account = ?, password = ?, email = ? where id = ?";
-        jdbcTemplate.queryAndGetUpdateRowsCount(connection, sql, user.getAccount(), user.getPassword(), user.getEmail(),
+        jdbcTemplate.queryAndGetUpdateRowsCount(sql, user.getAccount(), user.getPassword(), user.getEmail(),
                 user.getId());
     }
 
-    public List<User> findAll(Connection connection) {
+    public List<User> findAll() {
         final var sql = "select id, account, password, email from users";
-        return jdbcTemplate.queryAndGetResults(connection, sql, RESULT_SET_PARSER);
+        return jdbcTemplate.queryAndGetResults(sql, RESULT_SET_PARSER);
     }
 
-    public User findById(Connection connection, final Long id) {
+    public User findById(final Long id) {
         final var sql = "select id, account, password, email from users where id = ?";
-        return jdbcTemplate.queryAndGetResult(connection, sql, RESULT_SET_PARSER, id);
+        return jdbcTemplate.queryAndGetResult(sql, RESULT_SET_PARSER, id);
     }
 
-    public User findByAccount(Connection connection, final String account) {
+    public User findByAccount(final String account) {
         final var sql = "select id, account, password, email from users where account = ?";
-        return jdbcTemplate.queryAndGetResult(connection, sql, RESULT_SET_PARSER, account);
+        return jdbcTemplate.queryAndGetResult(sql, RESULT_SET_PARSER, account);
     }
 }

--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -2,7 +2,6 @@ package com.techcourse.dao;
 
 import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.domain.UserHistory;
-import java.sql.Connection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,11 +15,10 @@ public class UserHistoryDao {
         this.jdbcTemplate = jdbcTemplate;
     }
 
-    public void log(Connection connection, final UserHistory userHistory) {
+    public void log(final UserHistory userHistory) {
         final var sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
         log.debug("query : {}", sql);
         jdbcTemplate.queryAndGetUpdateRowsCount(
-                connection,
                 sql,
                 userHistory.getUserId(),
                 userHistory.getAccount(),

--- a/app/src/main/java/com/techcourse/service/AppUserService.java
+++ b/app/src/main/java/com/techcourse/service/AppUserService.java
@@ -1,0 +1,32 @@
+package com.techcourse.service;
+
+import com.techcourse.dao.UserDao;
+import com.techcourse.dao.UserHistoryDao;
+import com.techcourse.domain.User;
+import com.techcourse.domain.UserHistory;
+
+public class AppUserService implements UserService{
+
+    private final UserDao userDao;
+    private final UserHistoryDao userHistoryDao;
+
+    public AppUserService(final UserDao userDao, final UserHistoryDao userHistoryDao) {
+        this.userDao = userDao;
+        this.userHistoryDao = userHistoryDao;
+    }
+
+    public User findById(final long id) {
+        return userDao.findById(id);
+    }
+
+    public void insert(final User user) {
+        userDao.insert(user);
+    }
+
+    public void changePassword(final long id, final String newPassword, final String createBy) {
+        final var user = findById(id);
+        user.changePassword(newPassword);
+        userDao.update(user);
+        userHistoryDao.log(new UserHistory(user, createBy));
+    }
+}

--- a/app/src/main/java/com/techcourse/service/TxUserService.java
+++ b/app/src/main/java/com/techcourse/service/TxUserService.java
@@ -30,7 +30,7 @@ public class TxUserService implements UserService {
     @Override
     public void changePassword(long id, String newPassword, String createBy) {
         DataSource dataSource = DataSourceConfig.getInstance();
-        TransactionSynchronizationManager.getTransactionStartedResource(dataSource);
+        TransactionSynchronizationManager.bindAndStartTransaction(dataSource);
         try {
             appUserService.changePassword(id, newPassword, createBy);
         }catch (Exception e) {

--- a/app/src/main/java/com/techcourse/service/TxUserService.java
+++ b/app/src/main/java/com/techcourse/service/TxUserService.java
@@ -20,7 +20,8 @@ public class TxUserService implements UserService {
 
     @Override
     public void insert(User user) {
-        appUserService.insert(user);
+        DataSource dataSource = DataSourceConfig.getInstance();
+        TransactionManager.execute(dataSource,() -> appUserService.insert(user));
     }
 
     @Override

--- a/app/src/main/java/com/techcourse/service/TxUserService.java
+++ b/app/src/main/java/com/techcourse/service/TxUserService.java
@@ -1,0 +1,43 @@
+package com.techcourse.service;
+
+import com.interface21.dao.DataAccessException;
+import com.interface21.transaction.support.TransactionSynchronizationManager;
+import com.techcourse.config.DataSourceConfig;
+import com.techcourse.domain.User;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TxUserService implements UserService {
+
+    private static final Logger log = LoggerFactory.getLogger(TxUserService.class);
+    private final AppUserService appUserService;
+
+    public TxUserService(AppUserService appUserService) {
+        this.appUserService = appUserService;
+    }
+
+    @Override
+    public User findById(long id) {
+        return appUserService.findById(id);
+    }
+
+    @Override
+    public void insert(User user) {
+        appUserService.insert(user);
+    }
+
+    @Override
+    public void changePassword(long id, String newPassword, String createBy) {
+        DataSource dataSource = DataSourceConfig.getInstance();
+        TransactionSynchronizationManager.getTransactionStartedResource(dataSource);
+        try {
+            appUserService.changePassword(id, newPassword, createBy);
+        }catch (Exception e) {
+            log.error(e.getMessage(), e);
+            TransactionSynchronizationManager.unbindAndRollback(dataSource);
+            throw new DataAccessException(e);
+        }
+        TransactionSynchronizationManager.unbindAndCommit(dataSource);
+    }
+}

--- a/app/src/main/java/com/techcourse/service/TxUserService.java
+++ b/app/src/main/java/com/techcourse/service/TxUserService.java
@@ -1,16 +1,12 @@
 package com.techcourse.service;
 
-import com.interface21.dao.DataAccessException;
-import com.interface21.transaction.support.TransactionSynchronizationManager;
+import com.interface21.transaction.support.TransactionManager;
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.domain.User;
 import javax.sql.DataSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TxUserService implements UserService {
 
-    private static final Logger log = LoggerFactory.getLogger(TxUserService.class);
     private final AppUserService appUserService;
 
     public TxUserService(AppUserService appUserService) {
@@ -30,14 +26,6 @@ public class TxUserService implements UserService {
     @Override
     public void changePassword(long id, String newPassword, String createBy) {
         DataSource dataSource = DataSourceConfig.getInstance();
-        TransactionSynchronizationManager.bindAndStartTransaction(dataSource);
-        try {
-            appUserService.changePassword(id, newPassword, createBy);
-        }catch (Exception e) {
-            log.error(e.getMessage(), e);
-            TransactionSynchronizationManager.unbindAndRollback(dataSource);
-            throw new DataAccessException(e);
-        }
-        TransactionSynchronizationManager.unbindAndCommit(dataSource);
+        TransactionManager.execute(dataSource, () -> appUserService.changePassword(id, newPassword, createBy));
     }
 }

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -1,32 +1,11 @@
 package com.techcourse.service;
 
-import com.techcourse.dao.UserDao;
-import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
-import com.techcourse.domain.UserHistory;
 
-public class UserService {
+public interface UserService {
+    User findById(final long id);
 
-    private final UserDao userDao;
-    private final UserHistoryDao userHistoryDao;
+    void insert(final User user);
 
-    public UserService(final UserDao userDao, final UserHistoryDao userHistoryDao) {
-        this.userDao = userDao;
-        this.userHistoryDao = userHistoryDao;
-    }
-
-    public User findById(final long id) {
-        return userDao.findById(id);
-    }
-
-    public void insert(final User user) {
-        userDao.insert(user);
-    }
-
-    public void changePassword(final long id, final String newPassword, final String createBy) {
-        final var user = findById(id);
-        user.changePassword(newPassword);
-        userDao.update(user);
-        userHistoryDao.log(new UserHistory(user, createBy));
-    }
+    void changePassword(final long id, final String newPassword, final String createBy);
 }

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -1,89 +1,32 @@
 package com.techcourse.service;
 
-import com.interface21.dao.DataAccessException;
 import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.domain.UserHistory;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import javax.sql.DataSource;
 
 public class UserService {
 
     private final UserDao userDao;
     private final UserHistoryDao userHistoryDao;
-    private final DataSource dataSource;
 
-    public UserService(final UserDao userDao, final UserHistoryDao userHistoryDao, final DataSource dataSource) {
+    public UserService(final UserDao userDao, final UserHistoryDao userHistoryDao) {
         this.userDao = userDao;
         this.userHistoryDao = userHistoryDao;
-        this.dataSource = dataSource;
     }
 
     public User findById(final long id) {
-        return manageTransaction(connection -> {
-            return userDao.findById(connection, id);
-        });
+        return userDao.findById(id);
     }
 
     public void insert(final User user) {
-        manageTransaction(connection -> {
-            userDao.insert(connection, user);
-        });
+        userDao.insert(user);
     }
 
     public void changePassword(final long id, final String newPassword, final String createBy) {
-        manageTransaction(connection -> {
-            final var user = findById(id);
-            user.changePassword(newPassword);
-            userDao.update(connection, user);
-            userHistoryDao.log(connection, new UserHistory(user, createBy));
-        });
-    }
-
-    private <T> T manageTransaction(Function<Connection, T> businessLogic) {
-        Connection connection = getConnection();
-        try {
-            connection.setAutoCommit(false);
-            T result = businessLogic.apply(connection);
-            connection.commit();
-            return result;
-        }catch (SQLException e) {
-            try {
-                connection.rollback();
-            } catch (SQLException ex) {
-                throw new DataAccessException(ex);
-            }
-            throw new DataAccessException(e);
-        }
-    }
-
-    private Connection getConnection() {
-        Connection connection;
-        try {
-            connection = dataSource.getConnection();
-        } catch (SQLException e) {
-            throw new DataAccessException(e);
-        }
-        return connection;
-    }
-
-    private void manageTransaction(Consumer<Connection> businessLogic) {
-        Connection connection = getConnection();
-        try {
-            connection.setAutoCommit(false);
-            businessLogic.accept(connection);
-            connection.commit();
-        }catch (SQLException e) {
-            try {
-                connection.rollback();
-            } catch (SQLException ex) {
-                throw new DataAccessException(ex);
-            }
-            throw new DataAccessException(e);
-        }
+        final var user = findById(id);
+        user.changePassword(newPassword);
+        userDao.update(user);
+        userHistoryDao.log(new UserHistory(user, createBy));
     }
 }

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -6,70 +6,66 @@ import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
-import java.sql.SQLException;
-import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class UserDaoTest {
 
     private UserDao userDao;
-    private DataSource dataSource;
 
     @BeforeEach
-    void setup() throws SQLException {
-        dataSource = DataSourceConfig.getInstance();
-        DatabasePopulatorUtils.execute(dataSource);
+    void setup() {
+        DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
 
-        JdbcTemplate jdbcTemplate = new JdbcTemplate();
+        JdbcTemplate jdbcTemplate = new JdbcTemplate(DataSourceConfig.getInstance());
         userDao = new UserDao(jdbcTemplate);
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
-        userDao.insert(dataSource.getConnection(), user);
+        userDao.insert(user);
     }
 
     @Test
-    void findAll() throws SQLException {
-        final var users = userDao.findAll(dataSource.getConnection());
+    void findAll() {
+        final var users = userDao.findAll();
 
         assertThat(users).isNotEmpty();
     }
 
     @Test
-    void findById() throws SQLException {
-        final var user = userDao.findById(dataSource.getConnection(),1L);
+    void findById() {
+        final var user = userDao.findById(1L);
 
         assertThat(user.getAccount()).isEqualTo("gugu");
     }
 
     @Test
-    void findByAccount() throws SQLException {
-        userDao.insert(dataSource.getConnection(),new User("robin", "password", "robin980108@naver.com"));
+    void findByAccount() {
+        userDao.insert(new User("robin", "password", "robin980108@naver.com"));
         final var account = "robin";
-        final var user = userDao.findByAccount(dataSource.getConnection(), account);
+        final var user = userDao.findByAccount(account);
 
         assertThat(user.getAccount()).isEqualTo(account);
     }
 
     @Test
-    void insert() throws SQLException {
+    void insert() {
         final var account = "insert-gugu";
         final var user = new User(account, "password", "hkkang@woowahan.com");
-        userDao.insert(dataSource.getConnection(), user);
+        userDao.insert(user);
 
-        final var actual = userDao.findById(dataSource.getConnection(), 2L);
+        final var actual = userDao.findById(2L);
 
         assertThat(actual.getAccount()).isEqualTo(account);
     }
 
     @Test
-    void update() throws SQLException {
+    void update() {
         final var newPassword = "password99";
-        final var user = userDao.findById(dataSource.getConnection(), 1L);
+        final var user = userDao.findById(1L);
         user.changePassword(newPassword);
 
-        userDao.update(dataSource.getConnection(), user);
+        userDao.update(user);
 
-        final var actual = userDao.findById(dataSource.getConnection(), 1L);
+        final var actual = userDao.findById(1L);
 
         assertThat(actual.getPassword()).isEqualTo(newPassword);
     }

--- a/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
+++ b/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
@@ -1,10 +1,9 @@
 package com.techcourse.service;
 
-import com.interface21.dao.DataAccessException;
-import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.UserHistory;
-import java.sql.Connection;
+import com.interface21.dao.DataAccessException;
+import com.interface21.jdbc.core.JdbcTemplate;
 
 public class MockUserHistoryDao extends UserHistoryDao {
 
@@ -13,7 +12,7 @@ public class MockUserHistoryDao extends UserHistoryDao {
     }
 
     @Override
-    public void log(Connection connection, final UserHistory userHistory) {
+    public void log(final UserHistory userHistory) {
         throw new DataAccessException();
     }
 }

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -1,20 +1,18 @@
 package com.techcourse.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.interface21.dao.DataAccessException;
+import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
-import com.interface21.dao.DataAccessException;
-import com.interface21.jdbc.core.JdbcTemplate;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-@Disabled
 class UserServiceTest {
 
     private JdbcTemplate jdbcTemplate;
@@ -33,7 +31,7 @@ class UserServiceTest {
     @Test
     void testChangePassword() {
         final var userHistoryDao = new UserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao);
+        final var userService = new TxUserService(new AppUserService(userDao, userHistoryDao));
 
         final var newPassword = "qqqqq";
         final var createBy = "gugu";
@@ -48,13 +46,16 @@ class UserServiceTest {
     void testTransactionRollback() {
         // 트랜잭션 롤백 테스트를 위해 mock으로 교체
         final var userHistoryDao = new MockUserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao);
+        // 애플리케이션 서비스
+        final var appUserService = new AppUserService(userDao, userHistoryDao);
+        // 트랜잭션 서비스 추상화
+        final var userService = new TxUserService(appUserService);
 
         final var newPassword = "newPassword";
-        final var createBy = "gugu";
+        final var createdBy = "gugu";
         // 트랜잭션이 정상 동작하는지 확인하기 위해 의도적으로 MockUserHistoryDao에서 예외를 발생시킨다.
         assertThrows(DataAccessException.class,
-                () -> userService.changePassword(1L, newPassword, createBy));
+                () -> userService.changePassword(1L, newPassword, createdBy));
 
         final var actual = userService.findById(1L);
 

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -1,41 +1,39 @@
 package com.techcourse.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import com.interface21.dao.DataAccessException;
-import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
-import java.sql.SQLException;
-import javax.sql.DataSource;
+import com.interface21.dao.DataAccessException;
+import com.interface21.jdbc.core.JdbcTemplate;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Disabled
 class UserServiceTest {
 
     private JdbcTemplate jdbcTemplate;
     private UserDao userDao;
-    private DataSource dataSource;
 
     @BeforeEach
-    void setUp() throws SQLException {
-        dataSource = DataSourceConfig.getInstance();
-        this.jdbcTemplate = new JdbcTemplate();
+    void setUp() {
+        this.jdbcTemplate = new JdbcTemplate(DataSourceConfig.getInstance());
         this.userDao = new UserDao(jdbcTemplate);
 
         DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
-        userDao.insert(dataSource.getConnection(), user);
+        userDao.insert(user);
     }
 
     @Test
-    void testChangePassword() throws SQLException {
+    void testChangePassword() {
         final var userHistoryDao = new UserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao, dataSource);
+        final var userService = new UserService(userDao, userHistoryDao);
 
         final var newPassword = "qqqqq";
         final var createBy = "gugu";
@@ -50,7 +48,7 @@ class UserServiceTest {
     void testTransactionRollback() {
         // 트랜잭션 롤백 테스트를 위해 mock으로 교체
         final var userHistoryDao = new MockUserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao, dataSource);
+        final var userService = new UserService(userDao, userHistoryDao);
 
         final var newPassword = "newPassword";
         final var createBy = "gugu";

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -52,10 +52,10 @@ class UserServiceTest {
         final var userService = new TxUserService(appUserService);
 
         final var newPassword = "newPassword";
-        final var createdBy = "gugu";
+        final var createBy = "gugu";
         // 트랜잭션이 정상 동작하는지 확인하기 위해 의도적으로 MockUserHistoryDao에서 예외를 발생시킨다.
         assertThrows(DataAccessException.class,
-                () -> userService.changePassword(1L, newPassword, createdBy));
+                () -> userService.changePassword(1L, newPassword, createBy));
 
         final var actual = userService.findById(1L);
 

--- a/jdbc/src/main/java/com/interface21/dao/DataAccessException.java
+++ b/jdbc/src/main/java/com/interface21/dao/DataAccessException.java
@@ -1,8 +1,26 @@
 package com.interface21.dao;
 
+import java.util.concurrent.Callable;
+
 public class DataAccessException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
+
+    public static <T> T executeAndConvertException(Callable<T> callable) {
+        try {
+            return callable.call();
+        }catch (Exception e) {
+            throw new DataAccessException(e);
+        }
+    }
+
+    public static void executeAndConvertException(RunAndThrowable runAndThrowable) {
+        try {
+            runAndThrowable.run();
+        }catch (Throwable t) {
+            throw new DataAccessException(t);
+        }
+    }
 
     public DataAccessException() {
         super();
@@ -14,5 +32,10 @@ public class DataAccessException extends RuntimeException {
 
     public DataAccessException(Throwable cause) {
         super(cause);
+    }
+
+    @FunctionalInterface
+    public interface RunAndThrowable {
+        void run() throws Throwable;
     }
 }

--- a/jdbc/src/main/java/com/interface21/dao/DataAccessException.java
+++ b/jdbc/src/main/java/com/interface21/dao/DataAccessException.java
@@ -9,7 +9,7 @@ public class DataAccessException extends RuntimeException {
     public static <T> T executeAndConvertException(Callable<T> callable) {
         try {
             return callable.call();
-        }catch (Exception e) {
+        } catch (Exception e) {
             throw new DataAccessException(e);
         }
     }
@@ -17,7 +17,7 @@ public class DataAccessException extends RuntimeException {
     public static void executeAndConvertException(RunAndThrowable runAndThrowable) {
         try {
             runAndThrowable.run();
-        }catch (Throwable t) {
+        } catch (Throwable t) {
             throw new DataAccessException(t);
         }
     }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -6,6 +6,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
+import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,13 +14,19 @@ public class JdbcTemplate {
 
     private static final Logger log = LoggerFactory.getLogger(JdbcTemplate.class);
 
+    private final DataSource dataSource;
 
-    public int queryAndGetUpdateRowsCount(Connection connection, String sql, Object... parameters) {
-        return executeQueryExecutor(connection, PreparedStatement::executeUpdate, sql, parameters);
+    public JdbcTemplate(final DataSource dataSource) {
+        this.dataSource = dataSource;
     }
 
-    private <T> T executeQueryExecutor(Connection connection, QueryExecutor<T> queryExecutor, String sql, Object... parameters) {
+    public int queryAndGetUpdateRowsCount(String sql, Object... parameters) {
+        return executeQueryExecutor(PreparedStatement::executeUpdate, sql, parameters);
+    }
+
+    private <T> T executeQueryExecutor(QueryExecutor<T> queryExecutor, String sql, Object... parameters) {
         try (
+                Connection connection = dataSource.getConnection();
                 PreparedStatement preparedStatement = connection.prepareStatement(sql)
         ) {
             log.debug("query : {}", sql);
@@ -31,24 +38,23 @@ public class JdbcTemplate {
         }
     }
 
-    public <T> List<T> queryAndGetResults(Connection connection, String sql, ResultSetParser<T> resultSetParser, Object... parameters) {
-        return executeQueryExecutor(connection, sql, resultSetParser, new ListResultGenerator<>(), parameters);
+    public <T> List<T> queryAndGetResults(String sql, ResultSetParser<T> resultSetParser, Object... parameters) {
+        return executeQueryExecutor(sql, resultSetParser, new ListResultGenerator<>(), parameters);
     }
 
     private <T, R> R executeQueryExecutor(
-            Connection connection,
             String sql,
             ResultSetParser<T> resultSetParser,
             ResultGenerator<T, R> rResultGenerator,
             Object... parameters
     ) {
-        return executeQueryExecutor(connection, (preparedStatement) -> {
+        return executeQueryExecutor((preparedStatement) -> {
             ResultSet resultSet = preparedStatement.executeQuery();
             return rResultGenerator.generate(resultSetParser, resultSet);
         }, sql, parameters);
     }
 
-    public <T> T queryAndGetResult(Connection connection, String sql, ResultSetParser<T> resultSetParser, Object... parameters) {
-        return executeQueryExecutor(connection, sql, resultSetParser, new SingleResultGenerator<>(), parameters);
+    public <T> T queryAndGetResult(String sql, ResultSetParser<T> resultSetParser, Object... parameters) {
+        return executeQueryExecutor(sql, resultSetParser, new SingleResultGenerator<>(), parameters);
     }
 }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -26,10 +26,8 @@ public class JdbcTemplate {
     }
 
     private <T> T executeQueryExecutor(QueryExecutor<T> queryExecutor, String sql, Object... parameters) {
-        try (
-                Connection connection = DataSourceUtils.getConnection(dataSource);
-                PreparedStatement preparedStatement = connection.prepareStatement(sql)
-        ) {
+        Connection connection = DataSourceUtils.getConnection(dataSource);
+        try (PreparedStatement preparedStatement = connection.prepareStatement(sql)){
             log.debug("query : {}", sql);
             queryExecutor.setParameters(preparedStatement, parameters);
             return queryExecutor.execute(preparedStatement);

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -1,6 +1,7 @@
 package com.interface21.jdbc.core;
 
 import com.interface21.dao.DataAccessException;
+import com.interface21.jdbc.datasource.DataSourceUtils;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -26,7 +27,7 @@ public class JdbcTemplate {
 
     private <T> T executeQueryExecutor(QueryExecutor<T> queryExecutor, String sql, Object... parameters) {
         try (
-                Connection connection = dataSource.getConnection();
+                Connection connection = DataSourceUtils.getConnection(dataSource);
                 PreparedStatement preparedStatement = connection.prepareStatement(sql)
         ) {
             log.debug("query : {}", sql);

--- a/jdbc/src/main/java/com/interface21/jdbc/datasource/DataSourceUtils.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/datasource/DataSourceUtils.java
@@ -3,7 +3,6 @@ package com.interface21.jdbc.datasource;
 import com.interface21.jdbc.CannotGetJdbcConnectionException;
 import com.interface21.transaction.support.TransactionSynchronizationManager;
 import java.sql.Connection;
-import java.sql.SQLException;
 import javax.sql.DataSource;
 
 // 4단계 미션에서 사용할 것
@@ -13,14 +12,5 @@ public abstract class DataSourceUtils {
 
     public static Connection getConnection(DataSource dataSource) throws CannotGetJdbcConnectionException {
         return TransactionSynchronizationManager.getResource(dataSource);
-    }
-
-    public static void releaseConnection(DataSource dataSource) {
-        try {
-            Connection connection = TransactionSynchronizationManager.unbindResource(dataSource);
-            connection.close();
-        } catch (SQLException ex) {
-            throw new CannotGetJdbcConnectionException("Failed to close JDBC Connection");
-        }
     }
 }

--- a/jdbc/src/main/java/com/interface21/jdbc/datasource/DataSourceUtils.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/datasource/DataSourceUtils.java
@@ -2,10 +2,9 @@ package com.interface21.jdbc.datasource;
 
 import com.interface21.jdbc.CannotGetJdbcConnectionException;
 import com.interface21.transaction.support.TransactionSynchronizationManager;
-
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
+import javax.sql.DataSource;
 
 // 4단계 미션에서 사용할 것
 public abstract class DataSourceUtils {
@@ -13,22 +12,12 @@ public abstract class DataSourceUtils {
     private DataSourceUtils() {}
 
     public static Connection getConnection(DataSource dataSource) throws CannotGetJdbcConnectionException {
-        Connection connection = TransactionSynchronizationManager.getResource(dataSource);
-        if (connection != null) {
-            return connection;
-        }
-
-        try {
-            connection = dataSource.getConnection();
-            TransactionSynchronizationManager.bindResource(dataSource, connection);
-            return connection;
-        } catch (SQLException ex) {
-            throw new CannotGetJdbcConnectionException("Failed to obtain JDBC Connection", ex);
-        }
+        return TransactionSynchronizationManager.getResource(dataSource);
     }
 
-    public static void releaseConnection(Connection connection, DataSource dataSource) {
+    public static void releaseConnection(DataSource dataSource) {
         try {
+            Connection connection = TransactionSynchronizationManager.unbindResource(dataSource);
             connection.close();
         } catch (SQLException ex) {
             throw new CannotGetJdbcConnectionException("Failed to close JDBC Connection");

--- a/jdbc/src/main/java/com/interface21/transaction/support/TransactionManager.java
+++ b/jdbc/src/main/java/com/interface21/transaction/support/TransactionManager.java
@@ -1,0 +1,50 @@
+package com.interface21.transaction.support;
+
+import com.interface21.dao.DataAccessException;
+import com.interface21.dao.DataAccessException.RunAndThrowable;
+import java.sql.Connection;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TransactionManager {
+
+    private static final Logger log = LoggerFactory.getLogger(TransactionManager.class);
+
+    private TransactionManager(){
+
+    }
+
+    public static void execute(DataSource dataSource, RunAndThrowable runAndThrowable) {
+        bindAndStartTransaction(dataSource);
+        try {
+            runAndThrowable.run();
+            unbindAndCommit(dataSource);
+        } catch (Throwable e) {
+            log.error(e.getMessage(), e);
+            unbindAndRollback(dataSource);
+            throw new DataAccessException(e);
+        }
+    }
+
+    private static void bindAndStartTransaction(DataSource key) {
+        Connection connection = TransactionSynchronizationManager.getResource(key);
+        execute(() -> connection.setAutoCommit(false));
+    }
+
+    private static void unbindAndCommit(DataSource key) {
+        Connection connection = TransactionSynchronizationManager.unbindResource(key);
+        execute(connection::commit);
+        execute(connection::close);
+    }
+
+    private static void execute(RunAndThrowable runAndThrowable) {
+        DataAccessException.executeAndConvertException(runAndThrowable);
+    }
+
+    private static void unbindAndRollback(DataSource key) {
+        Connection connection = TransactionSynchronizationManager.unbindResource(key);
+        execute(connection::rollback);
+        execute(connection::close);
+    }
+}

--- a/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
+++ b/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
@@ -1,23 +1,60 @@
 package com.interface21.transaction.support;
 
-import javax.sql.DataSource;
+import com.interface21.dao.DataAccessException;
 import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.Map;
+import javax.sql.DataSource;
 
-public abstract class TransactionSynchronizationManager {
+public final class TransactionSynchronizationManager {
 
     private static final ThreadLocal<Map<DataSource, Connection>> resources = new ThreadLocal<>();
 
     private TransactionSynchronizationManager() {}
 
     public static Connection getResource(DataSource key) {
-        return null;
+        Map<DataSource, Connection> dataSourceConnectionMap = getDataSourceConnectionMap();
+        Connection connection = dataSourceConnectionMap.get(key);
+        if (connection == null || isClosed(connection)) {
+            bindResource(key, getConnection(key));
+            return getResource(key);
+        }
+        return connection;
+    }
+
+    private static boolean isClosed(Connection connection){
+        try {
+            return connection.isClosed();
+        } catch (SQLException e) {
+            throw new DataAccessException(e);
+        }
+    }
+
+    private static Connection getConnection(DataSource key){
+        try {
+            return key.getConnection();
+        } catch (SQLException e) {
+            throw new DataAccessException(e);
+        }
+    }
+
+    private static Map<DataSource, Connection> getDataSourceConnectionMap() {
+        Map<DataSource, Connection> dataSourceConnectionMap = resources.get();
+        if (dataSourceConnectionMap == null) {
+            resources.set(new HashMap<>());
+            dataSourceConnectionMap = resources.get();
+        }
+        return dataSourceConnectionMap;
     }
 
     public static void bindResource(DataSource key, Connection value) {
+        Map<DataSource, Connection> dataSourceConnectionMap = getDataSourceConnectionMap();
+        dataSourceConnectionMap.put(key, value);
     }
 
     public static Connection unbindResource(DataSource key) {
-        return null;
+        Map<DataSource, Connection> dataSourceConnectionMap = getDataSourceConnectionMap();
+        return dataSourceConnectionMap.remove(key);
     }
 }

--- a/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
+++ b/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
@@ -1,7 +1,6 @@
 package com.interface21.transaction.support;
 
 import com.interface21.dao.DataAccessException;
-import com.interface21.dao.DataAccessException.RunAndThrowable;
 import java.sql.Connection;
 import java.util.HashMap;
 import java.util.Map;
@@ -13,11 +12,6 @@ public final class TransactionSynchronizationManager {
     private static final ThreadLocal<Map<DataSource, Connection>> resources = new ThreadLocal<>();
 
     private TransactionSynchronizationManager() {}
-
-    public static void bindAndStartTransaction(DataSource key) {
-        Connection connection = getResource(key);
-        execute(() -> connection.setAutoCommit(false));
-    }
 
     public static Connection getResource(DataSource key) {
         Map<DataSource, Connection> dataSourceConnectionMap = getDataSourceConnectionMap();
@@ -31,20 +25,6 @@ public final class TransactionSynchronizationManager {
 
     private static <T> T executeAndReturn(Callable<T> callable) {
         return DataAccessException.executeAndConvertException(callable);
-    }
-
-    public static void unbindAndCommit(DataSource key) {
-        Connection connection = unbindResource(key);
-        execute(connection::commit);
-    }
-
-    private static void execute(RunAndThrowable runAndThrowable) {
-        DataAccessException.executeAndConvertException(runAndThrowable);
-    }
-
-    public static void unbindAndRollback(DataSource key) {
-        Connection connection = unbindResource(key);
-        execute(connection::rollback);
     }
 
     private static Map<DataSource, Connection> getDataSourceConnectionMap() {

--- a/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
+++ b/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
@@ -13,10 +13,9 @@ public final class TransactionSynchronizationManager {
 
     private TransactionSynchronizationManager() {}
 
-    public static Connection getTransactionStartedResource(DataSource key) {
+    public static void bindAndStartTransaction(DataSource key) {
         Connection connection = getResource(key);
-        startTransaction(connection);
-        return connection;
+        execute(() -> connection.setAutoCommit(false));
     }
 
     private static void startTransaction(Connection connection){

--- a/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
+++ b/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
@@ -13,6 +13,20 @@ public final class TransactionSynchronizationManager {
 
     private TransactionSynchronizationManager() {}
 
+    public static Connection getTransactionStartedResource(DataSource key) {
+        Connection connection = getResource(key);
+        startTransaction(connection);
+        return connection;
+    }
+
+    private static void startTransaction(Connection connection){
+        try {
+            connection.setAutoCommit(false);
+        } catch (SQLException e) {
+            throw new DataAccessException(e);
+        }
+    }
+
     public static Connection getResource(DataSource key) {
         Map<DataSource, Connection> dataSourceConnectionMap = getDataSourceConnectionMap();
         Connection connection = dataSourceConnectionMap.get(key);
@@ -38,6 +52,33 @@ public final class TransactionSynchronizationManager {
             throw new DataAccessException(e);
         }
     }
+
+    public static void unbindAndCommit(DataSource key) {
+        Connection connection = unbindResource(key);
+        commit(connection);
+    }
+
+    private static void commit(Connection connection) {
+        try {
+            connection.commit();
+        } catch (SQLException e) {
+            throw new DataAccessException(e);
+        }
+    }
+
+    public static void unbindAndRollback(DataSource key) {
+        Connection connection = unbindResource(key);
+        rollback(connection);
+    }
+
+    private static void rollback(Connection connection) {
+        try {
+            connection.rollback();
+        } catch (SQLException e) {
+            throw new DataAccessException(e);
+        }
+    }
+
 
     private static Map<DataSource, Connection> getDataSourceConnectionMap() {
         Map<DataSource, Connection> dataSourceConnectionMap = resources.get();

--- a/jdbc/src/test/java/com/interface21/jdbc/core/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/com/interface21/jdbc/core/JdbcTemplateTest.java
@@ -52,7 +52,7 @@ public class JdbcTemplateTest {
 
         when(preparedStatement.executeUpdate()).thenReturn(1);
 
-        int rowsAffected = jdbcTemplate.queryAndGetUpdateRowsCount(connection, sql, params);
+        int rowsAffected = jdbcTemplate.queryAndGetUpdateRowsCount(sql, params);
 
         assertThat(rowsAffected).isEqualTo(1);
 
@@ -74,7 +74,7 @@ public class JdbcTemplateTest {
 
         ResultSetParser<User> parser = userResultSetParser();
 
-        List<User> users = jdbcTemplate.queryAndGetResults(connection, sql, parser, params);
+        List<User> users = jdbcTemplate.queryAndGetResults(sql, parser, params);
 
         assertThat(users).isNotNull().hasSize(1);
         assertThat(users.getFirst().getName()).isEqualTo("John");
@@ -97,7 +97,7 @@ public class JdbcTemplateTest {
 
         ResultSetParser<User> parser = userResultSetParser();
 
-        User user = jdbcTemplate.queryAndGetResult(connection, sql, parser, params);
+        User user = jdbcTemplate.queryAndGetResult(sql, parser, params);
 
         assertThat(user).isNotNull();
         assertThat(user.getName()).isEqualTo("John");
@@ -122,7 +122,7 @@ public class JdbcTemplateTest {
 
         ResultSetParser<User> parser = userResultSetParser();
 
-        assertThatThrownBy(() -> jdbcTemplate.queryAndGetResult(connection, sql, parser, params))
+        assertThatThrownBy(() -> jdbcTemplate.queryAndGetResult(sql, parser, params))
                 .isInstanceOf(DataAccessException.class)
                 .hasMessage("여러개의 행이 조회되었습니다.");
 
@@ -141,7 +141,7 @@ public class JdbcTemplateTest {
 
         ResultSetParser<User> parser = userResultSetParser();
 
-        assertThatThrownBy(() -> jdbcTemplate.queryAndGetResult(connection, sql, parser, params))
+        assertThatThrownBy(() -> jdbcTemplate.queryAndGetResult(sql, parser, params))
                 .isInstanceOf(DataAccessException.class)
                 .hasMessage("행이 하나도 조회되지 않았습니다.");
 

--- a/study/src/test/java/aop/stage0/Stage0Test.java
+++ b/study/src/test/java/aop/stage0/Stage0Test.java
@@ -1,5 +1,9 @@
 package aop.stage0;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
 import aop.DataAccessException;
 import aop.StubUserHistoryDao;
 import aop.domain.User;
@@ -7,6 +11,7 @@ import aop.repository.UserDao;
 import aop.repository.UserHistoryDao;
 import aop.service.AppUserService;
 import aop.service.UserService;
+import java.lang.reflect.Proxy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -14,10 +19,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.PlatformTransactionManager;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 class Stage0Test {
@@ -45,7 +46,11 @@ class Stage0Test {
     @Test
     void testChangePassword() {
         final var appUserService = new AppUserService(userDao, userHistoryDao);
-        final UserService userService = null;
+        final UserService userService = (UserService) Proxy.newProxyInstance(
+                    UserService.class.getClassLoader(),
+                    new Class[]{UserService.class},
+                    new TransactionHandler(platformTransactionManager, appUserService)
+                );
 
         final var newPassword = "qqqqq";
         final var createBy = "gugu";
@@ -59,7 +64,12 @@ class Stage0Test {
     @Test
     void testTransactionRollback() {
         final var appUserService = new AppUserService(userDao, stubUserHistoryDao);
-        final UserService userService = null;
+
+        final UserService userService = (UserService) Proxy.newProxyInstance(
+                UserService.class.getClassLoader(),
+                new Class[]{UserService.class},
+                new TransactionHandler(platformTransactionManager, appUserService)
+        );
 
         final var newPassword = "newPassword";
         final var createBy = "gugu";

--- a/study/src/test/java/aop/stage0/TransactionHandler.java
+++ b/study/src/test/java/aop/stage0/TransactionHandler.java
@@ -1,15 +1,36 @@
 package aop.stage0;
 
+import aop.DataAccessException;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
 
 public class TransactionHandler implements InvocationHandler {
+
+    private final PlatformTransactionManager transactionManager;
+
+    private final Object target;
+
+    public TransactionHandler(PlatformTransactionManager transactionManager, Object target) {
+        this.transactionManager = transactionManager;
+        this.target = target;
+    }
 
     /**
      * @Transactional 어노테이션이 존재하는 메서드만 트랜잭션 기능을 적용하도록 만들어보자.
      */
     @Override
     public Object invoke(final Object proxy, final Method method, final Object[] args) throws Throwable {
-        return null;
+        final var transactionStatus = transactionManager.getTransaction(new DefaultTransactionDefinition());
+
+        try {
+            Object returnValue = method.invoke(target, args);
+            transactionManager.commit(transactionStatus);
+            return returnValue;
+        } catch (Exception e) {
+            transactionManager.rollback(transactionStatus);
+            throw new DataAccessException(e);
+        }
     }
 }

--- a/study/src/test/java/aop/stage1/TransactionAdvice.java
+++ b/study/src/test/java/aop/stage1/TransactionAdvice.java
@@ -1,15 +1,33 @@
 package aop.stage1;
 
+import aop.DataAccessException;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
 
 /**
  * 어드바이스(advice). 부가기능을 담고 있는 클래스
  */
 public class TransactionAdvice  implements MethodInterceptor {
 
+    private final PlatformTransactionManager transactionManager;
+
+    public TransactionAdvice(PlatformTransactionManager transactionManager) {
+        this.transactionManager = transactionManager;
+    }
+
     @Override
     public Object invoke(final MethodInvocation invocation) throws Throwable {
-        return null;
+        final var transactionStatus = transactionManager.getTransaction(new DefaultTransactionDefinition());
+
+        try {
+            Object returnValue = invocation.proceed();
+            transactionManager.commit(transactionStatus);
+            return returnValue;
+        } catch (Exception e) {
+            transactionManager.rollback(transactionStatus);
+            throw new DataAccessException(e);
+        }
     }
 }

--- a/study/src/test/java/aop/stage1/TransactionAdvisor.java
+++ b/study/src/test/java/aop/stage1/TransactionAdvisor.java
@@ -10,14 +10,23 @@ import org.springframework.aop.PointcutAdvisor;
  */
 public class TransactionAdvisor implements PointcutAdvisor {
 
+    private final TransactionPointcut pointcut;
+
+    private final TransactionAdvice advice;
+
+    public TransactionAdvisor(TransactionPointcut pointcut, TransactionAdvice advice) {
+        this.pointcut = pointcut;
+        this.advice = advice;
+    }
+
     @Override
     public Pointcut getPointcut() {
-        return null;
+        return pointcut;
     }
 
     @Override
     public Advice getAdvice() {
-        return null;
+        return advice;
     }
 
     @Override

--- a/study/src/test/java/aop/stage1/TransactionPointcut.java
+++ b/study/src/test/java/aop/stage1/TransactionPointcut.java
@@ -1,8 +1,8 @@
 package aop.stage1;
 
-import org.springframework.aop.support.StaticMethodMatcherPointcut;
-
+import aop.Transactional;
 import java.lang.reflect.Method;
+import org.springframework.aop.support.StaticMethodMatcherPointcut;
 
 /**
  * 포인트컷(pointcut). 어드바이스를 적용할 조인 포인트를 선별하는 클래스.
@@ -14,6 +14,6 @@ public class TransactionPointcut extends StaticMethodMatcherPointcut {
 
     @Override
     public boolean matches(final Method method, final Class<?> targetClass) {
-        return false;
+        return method.isAnnotationPresent(Transactional.class);
     }
 }

--- a/study/src/test/java/aop/stage2/AopConfig.java
+++ b/study/src/test/java/aop/stage2/AopConfig.java
@@ -1,8 +1,33 @@
 package aop.stage2;
 
+import aop.stage1.TransactionAdvice;
+import aop.stage1.TransactionAdvisor;
+import aop.stage1.TransactionPointcut;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
 
 @Configuration
 public class AopConfig {
 
+    private final PlatformTransactionManager platformTransactionManager;
+
+    public AopConfig(PlatformTransactionManager platformTransactionManager) {
+        this.platformTransactionManager = platformTransactionManager;
+    }
+
+    @Bean
+    public TransactionAdvisor transactionAdvisor() {
+        return new TransactionAdvisor(transactionPointcut(), transactionAdvice());
+    }
+
+    @Bean
+    public TransactionPointcut transactionPointcut() {
+        return new TransactionPointcut();
+    }
+
+    @Bean
+    public TransactionAdvice transactionAdvice() {
+        return new TransactionAdvice(platformTransactionManager);
+    }
 }

--- a/study/src/test/java/aop/stage2/AopConfig.java
+++ b/study/src/test/java/aop/stage2/AopConfig.java
@@ -3,6 +3,7 @@ package aop.stage2;
 import aop.stage1.TransactionAdvice;
 import aop.stage1.TransactionAdvisor;
 import aop.stage1.TransactionPointcut;
+import org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -29,5 +30,12 @@ public class AopConfig {
     @Bean
     public TransactionAdvice transactionAdvice() {
         return new TransactionAdvice(platformTransactionManager);
+    }
+
+    @Bean
+    public DefaultAdvisorAutoProxyCreator defaultAdvisorAutoProxyCreator() {
+        DefaultAdvisorAutoProxyCreator defaultAdvisorAutoProxyCreator = new DefaultAdvisorAutoProxyCreator();
+        defaultAdvisorAutoProxyCreator.setProxyTargetClass(true);
+        return defaultAdvisorAutoProxyCreator;
     }
 }

--- a/study/src/test/java/aop/stage2/Stage2Test.java
+++ b/study/src/test/java/aop/stage2/Stage2Test.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.aop.framework.autoproxy.AbstractAutoProxyCreator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
@@ -59,12 +58,5 @@ class Stage2Test {
         final var actual = userService.findById(1L);
 
         assertThat(actual.getPassword()).isNotEqualTo(newPassword);
-    }
-
-    @Test
-    void abstractAutoProxyCreator() {
-        AbstractAutoProxyCreator bean = applicationContext.getBean(AbstractAutoProxyCreator.class);
-
-        System.out.println(bean);
     }
 }

--- a/study/src/test/java/aop/stage2/Stage2Test.java
+++ b/study/src/test/java/aop/stage2/Stage2Test.java
@@ -1,5 +1,8 @@
 package aop.stage2;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import aop.DataAccessException;
 import aop.StubUserHistoryDao;
 import aop.domain.User;
@@ -7,11 +10,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.aop.framework.autoproxy.AbstractAutoProxyCreator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.springframework.context.ApplicationContext;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class Stage2Test {
@@ -19,10 +21,13 @@ class Stage2Test {
     private static final Logger log = LoggerFactory.getLogger(Stage2Test.class);
 
     @Autowired
+    private ApplicationContext applicationContext;
+    @Autowired
     private UserService userService;
 
     @Autowired
     private StubUserHistoryDao stubUserHistoryDao;
+
 
     @BeforeEach
     void setUp() {
@@ -37,6 +42,7 @@ class Stage2Test {
         userService.changePassword(1L, newPassword, createBy);
 
         final var actual = userService.findById(1L);
+
 
         assertThat(actual.getPassword()).isEqualTo(newPassword);
     }
@@ -53,5 +59,12 @@ class Stage2Test {
         final var actual = userService.findById(1L);
 
         assertThat(actual.getPassword()).isNotEqualTo(newPassword);
+    }
+
+    @Test
+    void abstractAutoProxyCreator() {
+        AbstractAutoProxyCreator bean = applicationContext.getBean(AbstractAutoProxyCreator.class);
+
+        System.out.println(bean);
     }
 }


### PR DESCRIPTION
드디어 마지막 단계네요! 이번 단계 구현의 핵심은 ThreadLocal과 Proxy (데코레이터 패턴)을 이용한 관심사 분리였어요.

### ThreadLocal

각 스레드에서만 접근 가능한 저장공간을 제공하는 API 입니다. 

내부적으로 ThreadLocalMap 이라는 일종의 해시 맵 자료구조를 이용해 동작합니다.

모든 Thread에는 내부적으로 `ThreadLocal.ThreadLocalMap threadLocals;` 이런 필드를 가지고 있습니다.

`ThreadLocal.get()` 은 내부적으로 `Thread.currentThread()` 호출을 통해 현재 실행중인 스레드의 저 필드에 접근하여 데이터를 가져옵니다.

설정하는  것 역시 비슷한 방식으로 이루어집니다.

참고로 로그가 어디서 발생했는지 추적하기 위해 사용되는 MDC의 LogBack 구현체가 내부적으로 ThreadLocal을 사용하더군요. (플젝에서 써서 알아봤어요.)
![image](https://github.com/user-attachments/assets/a4c4987c-d36f-4e23-b6ee-b1b9c37560f4)


### Proxy

프록시는 대리라는 의미 처럼 어떤 동작을 대신 처리하는 객체를 말합니다. 대리작업의 앞 뒤에 부가적인 작업을 하도록 구현하기 쉽기 때문에 이런 방식을 사용합니다. 그리고 이런 용도로 프록시를 사용하면 데코레이터 패턴에 해당합니다.

프록시를 사용한 다른 예시는 JPA 의 엔티티를 예로 들 수 있습니다. 단, 이때는 데코레이터 패턴보다는 프록시 패턴에 더 가깝습니다. 부가 기능을 제공하는 것 보단, 접근을 제어하는 것에 가깝기 때문입니다. 즉시 로딩과 레이지 로딩은 객체의 필드에 접근하는 방식을 제어하는 것이기 때문입니다.