### PR TITLE
[4단계 - JDBC 라이브러리 구현하기] 카고(정민호) 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -9,7 +9,6 @@ import org.slf4j.LoggerFactory;
 
 import com.interface21.jdbc.core.JdbcTemplate;
 import com.interface21.jdbc.core.RowMapper;
-import com.interface21.transaction.support.TransactionSynchronizationManager;
 import com.techcourse.domain.User;
 
 public class UserDao {
@@ -23,11 +22,9 @@ public class UserDao {
     );
 
     private final JdbcTemplate jdbcTemplate;
-    private final DataSource dataSource;
 
     public UserDao(final JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
-        this.dataSource = jdbcTemplate.getDataSource();
     }
 
     public void insert(final User user) {
@@ -42,12 +39,7 @@ public class UserDao {
 
     public void update(User user) {
         String sql = "update users set password = ? where id = ?";
-        jdbcTemplate.update(
-                TransactionSynchronizationManager.getResource(dataSource),
-                sql,
-                user.getPassword(),
-                user.getId()
-        );
+        jdbcTemplate.update(sql, user.getPassword(), user.getId());
     }
 
     public List<User> findAll() {

--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -1,6 +1,5 @@
 package com.techcourse.dao;
 
-import java.sql.Connection;
 import java.util.List;
 
 import javax.sql.DataSource;
@@ -10,6 +9,7 @@ import org.slf4j.LoggerFactory;
 
 import com.interface21.jdbc.core.JdbcTemplate;
 import com.interface21.jdbc.core.RowMapper;
+import com.interface21.transaction.support.TransactionSynchronizationManager;
 import com.techcourse.domain.User;
 
 public class UserDao {
@@ -23,9 +23,11 @@ public class UserDao {
     );
 
     private final JdbcTemplate jdbcTemplate;
+    private final DataSource dataSource;
 
     public UserDao(final JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
+        this.dataSource = jdbcTemplate.getDataSource();
     }
 
     public void insert(final User user) {
@@ -40,12 +42,12 @@ public class UserDao {
 
     public void update(User user) {
         String sql = "update users set password = ? where id = ?";
-        jdbcTemplate.update(sql, user.getPassword(), user.getId());
-    }
-
-    public void update(Connection connection, User user) {
-        String sql = "update users set password = ? where id = ?";
-        jdbcTemplate.update(connection, sql, user.getPassword(), user.getId());
+        jdbcTemplate.update(
+                TransactionSynchronizationManager.getResource(dataSource),
+                sql,
+                user.getPassword(),
+                user.getId()
+        );
     }
 
     public List<User> findAll() {

--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -1,14 +1,9 @@
 package com.techcourse.dao;
 
-import java.sql.Connection;
-
-import javax.sql.DataSource;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.interface21.jdbc.core.JdbcTemplate;
-import com.interface21.transaction.support.TransactionSynchronizationManager;
 import com.techcourse.domain.UserHistory;
 
 public class UserHistoryDao {
@@ -16,18 +11,15 @@ public class UserHistoryDao {
     private static final Logger log = LoggerFactory.getLogger(UserHistoryDao.class);
 
     private final JdbcTemplate jdbcTemplate;
-    private final DataSource dataSource;
 
     public UserHistoryDao(final JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
-        this.dataSource = jdbcTemplate.getDataSource();
     }
 
     public void log(UserHistory userHistory) {
         String sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
 
         jdbcTemplate.update(
-                TransactionSynchronizationManager.getResource(dataSource),
                 sql,
                 userHistory.getUserId(),
                 userHistory.getAccount(),

--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -2,10 +2,13 @@ package com.techcourse.dao;
 
 import java.sql.Connection;
 
+import javax.sql.DataSource;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.interface21.jdbc.core.JdbcTemplate;
+import com.interface21.transaction.support.TransactionSynchronizationManager;
 import com.techcourse.domain.UserHistory;
 
 public class UserHistoryDao {
@@ -13,30 +16,18 @@ public class UserHistoryDao {
     private static final Logger log = LoggerFactory.getLogger(UserHistoryDao.class);
 
     private final JdbcTemplate jdbcTemplate;
+    private final DataSource dataSource;
 
     public UserHistoryDao(final JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
+        this.dataSource = jdbcTemplate.getDataSource();
     }
 
     public void log(UserHistory userHistory) {
         String sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
 
         jdbcTemplate.update(
-                sql,
-                userHistory.getUserId(),
-                userHistory.getAccount(),
-                userHistory.getPassword(),
-                userHistory.getEmail(),
-                userHistory.getCreatedAt(),
-                userHistory.getCreateBy()
-        );
-    }
-
-    public void log(Connection connection, UserHistory userHistory) {
-        String sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
-
-        jdbcTemplate.update(
-                connection,
+                TransactionSynchronizationManager.getResource(dataSource),
                 sql,
                 userHistory.getUserId(),
                 userHistory.getAccount(),

--- a/app/src/main/java/com/techcourse/service/AppUserService.java
+++ b/app/src/main/java/com/techcourse/service/AppUserService.java
@@ -1,0 +1,35 @@
+package com.techcourse.service;
+
+import com.techcourse.dao.UserDao;
+import com.techcourse.dao.UserHistoryDao;
+import com.techcourse.domain.User;
+import com.techcourse.domain.UserHistory;
+
+public class AppUserService implements UserService {
+
+    private final UserDao userDao;
+    private final UserHistoryDao userHistoryDao;
+
+    public AppUserService(UserDao userDao, UserHistoryDao userHistoryDao) {
+        this.userDao = userDao;
+        this.userHistoryDao = userHistoryDao;
+    }
+
+    @Override
+    public User findById(long id) {
+        return userDao.findById(id);
+    }
+
+    @Override
+    public void save(User user) {
+        userDao.insert(user);
+    }
+
+    @Override
+    public void changePassword(long id, String newPassword, String createdBy) {
+        User user = findById(id);
+        user.changePassword(newPassword);
+        userDao.update(user);
+        userHistoryDao.log(new UserHistory(user, createdBy));
+    }
+}

--- a/app/src/main/java/com/techcourse/service/TxUserService.java
+++ b/app/src/main/java/com/techcourse/service/TxUserService.java
@@ -37,12 +37,18 @@ public class TxUserService implements UserService {
 
     @Override
     public void changePassword(long id, String newPassword, String createdBy) {
+        executeWithTransaction(() -> {
+            userService.changePassword(id, newPassword, createdBy);
+        });
+    }
+
+    private void executeWithTransaction(Runnable action) {
         Connection connection = DataSourceUtils.getConnection(dataSource);
 
         try {
             connection.setAutoCommit(false);
 
-            userService.changePassword(id, newPassword, createdBy);
+            action.run();
 
             connection.commit();
         } catch (SQLException | DataAccessException e) {

--- a/app/src/main/java/com/techcourse/service/TxUserService.java
+++ b/app/src/main/java/com/techcourse/service/TxUserService.java
@@ -1,0 +1,65 @@
+package com.techcourse.service;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.interface21.dao.DataAccessException;
+import com.interface21.jdbc.datasource.DataSourceUtils;
+import com.techcourse.config.DataSourceConfig;
+import com.techcourse.domain.User;
+
+public class TxUserService implements UserService {
+
+    private static final Logger log = LoggerFactory.getLogger(TxUserService.class);
+
+    private final UserService userService;
+    private final DataSource dataSource;
+
+    public TxUserService(UserService userService) {
+        this.userService = userService;
+        this.dataSource = DataSourceConfig.getInstance();
+    }
+
+    @Override
+    public User findById(long id) {
+        return userService.findById(id);
+    }
+
+    @Override
+    public void save(User user) {
+        userService.save(user);
+    }
+
+    @Override
+    public void changePassword(long id, String newPassword, String createdBy) {
+        Connection connection = DataSourceUtils.getConnection(dataSource);
+
+        try {
+            connection.setAutoCommit(false);
+
+            userService.changePassword(id, newPassword, createdBy);
+
+            connection.commit();
+        } catch (SQLException | DataAccessException e) {
+            log.error(e.getMessage(), e);
+            rollback(connection);
+            throw new DataAccessException("트랜잭션 수행 중 예외가 발생해 트랜잭션을 rollback 합니다.", e);
+        } finally {
+            DataSourceUtils.releaseConnection(connection, dataSource);
+        }
+    }
+
+    private void rollback(Connection connection) {
+        try {
+            connection.rollback();
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+            throw new DataAccessException("rollback에 실패했습니다.", e);
+        }
+    }
+}

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -1,73 +1,10 @@
 package com.techcourse.service;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-
-import javax.sql.DataSource;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.interface21.dao.DataAccessException;
-import com.interface21.jdbc.datasource.DataSourceUtils;
-import com.techcourse.dao.UserDao;
-import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
-import com.techcourse.domain.UserHistory;
 
-public class UserService {
+public interface UserService {
 
-    private static final Logger log = LoggerFactory.getLogger(UserService.class);
-
-    private final UserDao userDao;
-    private final UserHistoryDao userHistoryDao;
-    private final DataSource dataSource;
-
-    public UserService(final UserDao userDao, final UserHistoryDao userHistoryDao) {
-        this.userDao = userDao;
-        this.userHistoryDao = userHistoryDao;
-        this.dataSource = userDao.getDataSource();
-    }
-
-    public User findById(final long id) {
-        return userDao.findById(id);
-    }
-
-    public void insert(final User user) {
-        userDao.insert(user);
-    }
-
-    public void changePasswordWithTransaction(final long id, final String newPassword, final String createBy) {
-        Connection connection = DataSourceUtils.getConnection(dataSource);
-
-        try {
-            connection.setAutoCommit(false);
-
-            changePassword(id, newPassword, createBy);
-
-            connection.commit();
-        } catch (SQLException | DataAccessException e) {
-            log.error(e.getMessage(), e);
-            rollback(connection);
-            throw new DataAccessException("트랜잭션 수행 중 예외가 발생해 트랜잭션을 rollback 합니다.", e);
-        } finally {
-            DataSourceUtils.releaseConnection(connection, dataSource);
-        }
-    }
-
-    private void changePassword(long id, String newPassword, String createBy) {
-        User user = findById(id);
-        user.changePassword(newPassword);
-        userDao.update(user);
-        userHistoryDao.log(new UserHistory(user, createBy));
-    }
-
-    private void rollback(Connection connection) {
-        try {
-            connection.rollback();
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new DataAccessException("rollback에 실패했습니다.", e);
-        }
-    }
+    User findById(long id);
+    void save(User user);
+    void changePassword(long id, String newPassword, String createdBy);
 }

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -1,19 +1,18 @@
 package com.techcourse.dao;
 
-import com.interface21.jdbc.core.JdbcTemplate;
-import com.interface21.jdbc.datasource.DataSourceUtils;
-import com.interface21.transaction.support.TransactionSynchronizationManager;
-import com.techcourse.config.DataSourceConfig;
-import com.techcourse.domain.User;
-import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.sql.DataSource;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import javax.sql.DataSource;
+import com.interface21.jdbc.core.JdbcTemplate;
+import com.interface21.jdbc.datasource.DataSourceUtils;
+import com.techcourse.config.DataSourceConfig;
+import com.techcourse.domain.User;
+import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
 
 class UserDaoTest {
 
@@ -26,7 +25,6 @@ class UserDaoTest {
         dataSource = DataSourceConfig.getInstance();
         DatabasePopulatorUtils.execute(dataSource);
         jdbcTemplate = new JdbcTemplate(dataSource);
-        TransactionSynchronizationManager.bindResource(dataSource, DataSourceUtils.getConnection(dataSource));
         userDao = new UserDao(jdbcTemplate);
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
         userDao.insert(user);
@@ -36,7 +34,7 @@ class UserDaoTest {
     void tearDown() {
         String truncateSql = "TRUNCATE TABLE users RESTART IDENTITY";
         jdbcTemplate.update(truncateSql);
-        DataSourceUtils.releaseConnection(TransactionSynchronizationManager.getResource(dataSource), dataSource);
+        DataSourceUtils.releaseConnection(DataSourceUtils.getConnection(dataSource), dataSource);
     }
 
     @Test

--- a/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
+++ b/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
@@ -1,7 +1,5 @@
 package com.techcourse.service;
 
-import java.sql.Connection;
-
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.UserHistory;
 import com.interface21.dao.DataAccessException;
@@ -14,7 +12,7 @@ public class MockUserHistoryDao extends UserHistoryDao {
     }
 
     @Override
-    public void log(Connection connection, UserHistory userHistory) {
+    public void log(UserHistory userHistory) {
         throw new DataAccessException();
     }
 }

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -72,6 +72,6 @@ class UserServiceTest {
                 () -> userService.changePassword(1L, newPassword, createdBy));
 
         // then
-        assertThat(userService.findById(1L)).isNotEqualTo(newPassword);
+        assertThat(userService.findById(1L).getPassword()).isNotEqualTo(newPassword);
     }
 }

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -44,7 +44,8 @@ class UserServiceTest {
     void testChangePassword() {
         // given
         final var userHistoryDao = new UserHistoryDao(jdbcTemplate);
-        final var userService = new AppUserService(userDao, userHistoryDao);
+        final var appUserService = new AppUserService(userDao, userHistoryDao);
+        final var userService = new TxUserService(appUserService);
 
         final var newPassword = "qqqqq";
         final var createBy = "gugu";

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -44,13 +44,13 @@ class UserServiceTest {
     void testChangePassword() {
         // given
         final var userHistoryDao = new UserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao);
+        final var userService = new AppUserService(userDao, userHistoryDao);
 
         final var newPassword = "qqqqq";
         final var createBy = "gugu";
 
         // when
-        userService.changePasswordWithTransaction(1L, newPassword, createBy);
+        userService.changePassword(1L, newPassword, createBy);
 
         // then
         assertThat(userService.findById(1L).getPassword()).isEqualTo(newPassword);
@@ -61,16 +61,17 @@ class UserServiceTest {
     void testTransactionRollback() {
         // given
         final var userHistoryDao = new MockUserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao);
+        final var appUserService = new AppUserService(userDao, userHistoryDao);
+        final var userService = new TxUserService(appUserService);
 
         final var newPassword = "newPassword";
-        final var createBy = "gugu";
+        final var createdBy = "gugu";
 
         // when
         assertThrows(DataAccessException.class,
-                () -> userService.changePasswordWithTransaction(1L, newPassword, createBy));
+                () -> userService.changePassword(1L, newPassword, createdBy));
 
         // then
-        assertThat(userService.findById(1L).getPassword()).isNotEqualTo(newPassword);
+        assertThat(userService.findById(1L)).isNotEqualTo(newPassword);
     }
 }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.interface21.dao.DataAccessException;
+import com.interface21.jdbc.datasource.DataSourceUtils;
 
 public class JdbcTemplate {
 
@@ -28,20 +29,8 @@ public class JdbcTemplate {
     }
 
     public void update(String sql, Object... parameters) {
-        try (Connection conn = dataSource.getConnection();
-             PreparedStatement pstmt = conn.prepareStatement(sql)) {
-            log.debug("query : {}", sql);
-
-            setParameters(pstmt, parameters);
-            pstmt.executeUpdate();
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new DataAccessException(String.format(SQL_EXCEPTION_MESSAGE, sql), e);
-        }
-    }
-
-    public void update(Connection conn, String sql, Object... parameters) {
-        try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
+        Connection connection = DataSourceUtils.getConnection(dataSource);
+        try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
             log.debug("query : {}", sql);
 
             setParameters(pstmt, parameters);

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -42,8 +42,8 @@ public class JdbcTemplate {
     }
 
     public <T> List<T> query(String sql, RowMapper<T> rowMapper, Object... parameters) {
-        try (Connection conn = dataSource.getConnection();
-             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+        Connection connection = DataSourceUtils.getConnection(dataSource);
+        try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
             log.debug("query : {}", sql);
 
             setParameters(pstmt, parameters);
@@ -55,8 +55,8 @@ public class JdbcTemplate {
     }
 
     public <T> T queryForObject(String sql, RowMapper<T> rowMapper, Object... parameters) {
-        try (Connection conn = dataSource.getConnection();
-             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+        Connection connection = DataSourceUtils.getConnection(dataSource);
+        try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
             log.debug("query : {}", sql);
 
             setParameters(pstmt, parameters);

--- a/jdbc/src/main/java/com/interface21/jdbc/datasource/DataSourceUtils.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/datasource/DataSourceUtils.java
@@ -30,6 +30,7 @@ public abstract class DataSourceUtils {
     public static void releaseConnection(Connection connection, DataSource dataSource) {
         try {
             connection.close();
+            TransactionSynchronizationManager.unbindResource(dataSource);
         } catch (SQLException ex) {
             throw new CannotGetJdbcConnectionException("Failed to close JDBC Connection");
         }

--- a/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
+++ b/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
@@ -11,13 +11,14 @@ public abstract class TransactionSynchronizationManager {
     private TransactionSynchronizationManager() {}
 
     public static Connection getResource(DataSource key) {
-        return null;
+        return resources.get().get(key);
     }
 
     public static void bindResource(DataSource key, Connection value) {
+        resources.get().put(key, value);
     }
 
     public static Connection unbindResource(DataSource key) {
-        return null;
+        return resources.get().remove(key);
     }
 }

--- a/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
+++ b/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
@@ -2,11 +2,12 @@ package com.interface21.transaction.support;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
+import java.util.HashMap;
 import java.util.Map;
 
 public abstract class TransactionSynchronizationManager {
 
-    private static final ThreadLocal<Map<DataSource, Connection>> resources = new ThreadLocal<>();
+    private static final ThreadLocal<Map<DataSource, Connection>> resources = ThreadLocal.withInitial(HashMap::new);
 
     private TransactionSynchronizationManager() {}
 

--- a/study/src/test/java/aop/stage0/Stage0Test.java
+++ b/study/src/test/java/aop/stage0/Stage0Test.java
@@ -7,6 +7,7 @@ import aop.repository.UserDao;
 import aop.repository.UserHistoryDao;
 import aop.service.AppUserService;
 import aop.service.UserService;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -18,6 +19,8 @@ import org.springframework.transaction.PlatformTransactionManager;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+import java.lang.reflect.Proxy;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 class Stage0Test {
@@ -45,7 +48,11 @@ class Stage0Test {
     @Test
     void testChangePassword() {
         final var appUserService = new AppUserService(userDao, userHistoryDao);
-        final UserService userService = null;
+        UserService userService = (UserService) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class[]{UserService.class},
+                new TransactionHandler(platformTransactionManager, appUserService)
+        );
 
         final var newPassword = "qqqqq";
         final var createBy = "gugu";
@@ -59,7 +66,11 @@ class Stage0Test {
     @Test
     void testTransactionRollback() {
         final var appUserService = new AppUserService(userDao, stubUserHistoryDao);
-        final UserService userService = null;
+        UserService userService = (UserService) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class[]{UserService.class},
+                new TransactionHandler(platformTransactionManager, appUserService)
+        );
 
         final var newPassword = "newPassword";
         final var createBy = "gugu";

--- a/study/src/test/java/aop/stage0/TransactionHandler.java
+++ b/study/src/test/java/aop/stage0/TransactionHandler.java
@@ -1,15 +1,49 @@
 package aop.stage0;
 
 import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+
+import aop.DataAccessException;
+import aop.Transactional;
 
 public class TransactionHandler implements InvocationHandler {
 
     /**
      * @Transactional 어노테이션이 존재하는 메서드만 트랜잭션 기능을 적용하도록 만들어보자.
      */
+
+    private final PlatformTransactionManager transactionManager;
+    private final Object target;
+
+    public TransactionHandler(PlatformTransactionManager transactionManager, Object target) {
+        this.transactionManager = transactionManager;
+        this.target = target;
+    }
+
     @Override
     public Object invoke(final Object proxy, final Method method, final Object[] args) throws Throwable {
-        return null;
+        Method targetMethod = target.getClass().getMethod(method.getName(), method.getParameterTypes());
+
+        if (targetMethod.isAnnotationPresent(Transactional.class)) {
+            return invokeWithTransaction(method, args);
+        }
+        return method.invoke(target, args);
+    }
+
+    private Object invokeWithTransaction(Method method, Object[] args) throws Throwable {
+        TransactionStatus transactionStatus = transactionManager.getTransaction(new DefaultTransactionDefinition());
+        try {
+            Object result = method.invoke(target, args);
+            transactionManager.commit(transactionStatus);
+            return result;
+        } catch (InvocationTargetException e) {
+            transactionManager.rollback(transactionStatus);
+            throw new DataAccessException(e);
+        }
     }
 }

--- a/study/src/test/java/aop/stage0/TransactionHandler.java
+++ b/study/src/test/java/aop/stage0/TransactionHandler.java
@@ -43,7 +43,7 @@ public class TransactionHandler implements InvocationHandler {
             return result;
         } catch (InvocationTargetException e) {
             transactionManager.rollback(transactionStatus);
-            throw new DataAccessException(e);
+            throw new DataAccessException("트랜잭션 수행 중 예외가 발생해 롤백합니다.", e);
         }
     }
 }

--- a/study/src/test/java/aop/stage1/Stage1Test.java
+++ b/study/src/test/java/aop/stage1/Stage1Test.java
@@ -5,10 +5,12 @@ import aop.StubUserHistoryDao;
 import aop.domain.User;
 import aop.repository.UserDao;
 import aop.repository.UserHistoryDao;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.aop.framework.ProxyFactoryBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -33,15 +35,26 @@ class Stage1Test {
     @Autowired
     private PlatformTransactionManager platformTransactionManager;
 
+    private ProxyFactoryBean proxyFactoryBean;
+
     @BeforeEach
     void setUp() {
+        proxyFactoryBean = new ProxyFactoryBean();
+        proxyFactoryBean.setProxyTargetClass(true);
+        TransactionPointcut pointcut = new TransactionPointcut();
+        TransactionAdvice advice = new TransactionAdvice(platformTransactionManager);
+        proxyFactoryBean.addAdvisor(new TransactionAdvisor(pointcut, advice));
+
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
         userDao.insert(user);
     }
 
     @Test
     void testChangePassword() {
-        final UserService userService = null;
+        UserService target = new UserService(userDao, userHistoryDao);
+        proxyFactoryBean.setTarget(target);
+
+        final UserService userService = (UserService) proxyFactoryBean.getObject();
 
         final var newPassword = "qqqqq";
         final var createBy = "gugu";
@@ -54,7 +67,10 @@ class Stage1Test {
 
     @Test
     void testTransactionRollback() {
-        final UserService userService = null;
+        UserService target = new UserService(userDao, stubUserHistoryDao);
+        proxyFactoryBean.setTarget(target);
+
+        final UserService userService = (UserService) proxyFactoryBean.getObject();
 
         final var newPassword = "newPassword";
         final var createBy = "gugu";

--- a/study/src/test/java/aop/stage1/TransactionAdvice.java
+++ b/study/src/test/java/aop/stage1/TransactionAdvice.java
@@ -31,7 +31,7 @@ public class TransactionAdvice implements MethodInterceptor {
             return result;
         } catch (InvocationTargetException | DataAccessException e) {
             transactionManager.rollback(transactionStatus);
-            throw new DataAccessException(e);
+            throw new DataAccessException("트랜잭션 수행 중 예외가 발생해 롤백합니다.", e);
         }
     }
 }

--- a/study/src/test/java/aop/stage1/TransactionAdvice.java
+++ b/study/src/test/java/aop/stage1/TransactionAdvice.java
@@ -1,15 +1,37 @@
 package aop.stage1;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+
+import aop.DataAccessException;
 
 /**
  * 어드바이스(advice). 부가기능을 담고 있는 클래스
  */
-public class TransactionAdvice  implements MethodInterceptor {
+public class TransactionAdvice implements MethodInterceptor {
+
+    private final PlatformTransactionManager transactionManager;
+
+    public TransactionAdvice(PlatformTransactionManager transactionManager) {
+        this.transactionManager = transactionManager;
+    }
 
     @Override
     public Object invoke(final MethodInvocation invocation) throws Throwable {
-        return null;
+        TransactionStatus transactionStatus = transactionManager.getTransaction(new DefaultTransactionDefinition());
+        try {
+            Object result = invocation.proceed();
+            transactionManager.commit(transactionStatus);
+            return result;
+        } catch (InvocationTargetException | DataAccessException e) {
+            transactionManager.rollback(transactionStatus);
+            throw new DataAccessException(e);
+        }
     }
 }

--- a/study/src/test/java/aop/stage1/TransactionAdvisor.java
+++ b/study/src/test/java/aop/stage1/TransactionAdvisor.java
@@ -10,14 +10,22 @@ import org.springframework.aop.PointcutAdvisor;
  */
 public class TransactionAdvisor implements PointcutAdvisor {
 
+    private final Pointcut pointcut;
+    private final Advice advice;
+
+    public TransactionAdvisor(Pointcut pointcut, Advice advice) {
+        this.pointcut = pointcut;
+        this.advice = advice;
+    }
+
     @Override
     public Pointcut getPointcut() {
-        return null;
+        return pointcut;
     }
 
     @Override
     public Advice getAdvice() {
-        return null;
+        return advice;
     }
 
     @Override

--- a/study/src/test/java/aop/stage1/TransactionPointcut.java
+++ b/study/src/test/java/aop/stage1/TransactionPointcut.java
@@ -4,6 +4,8 @@ import org.springframework.aop.support.StaticMethodMatcherPointcut;
 
 import java.lang.reflect.Method;
 
+import aop.Transactional;
+
 /**
  * 포인트컷(pointcut). 어드바이스를 적용할 조인 포인트를 선별하는 클래스.
  * TransactionPointcut 클래스는 메서드를 대상으로 조인 포인트를 찾는다.
@@ -14,6 +16,6 @@ public class TransactionPointcut extends StaticMethodMatcherPointcut {
 
     @Override
     public boolean matches(final Method method, final Class<?> targetClass) {
-        return false;
+        return method.isAnnotationPresent(Transactional.class);
     }
 }

--- a/study/src/test/java/aop/stage2/AopConfig.java
+++ b/study/src/test/java/aop/stage2/AopConfig.java
@@ -1,8 +1,38 @@
 package aop.stage2;
 
+import org.aopalliance.aop.Advice;
+import org.springframework.aop.Pointcut;
+import org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import aop.stage1.TransactionAdvice;
+import aop.stage1.TransactionAdvisor;
+import aop.stage1.TransactionPointcut;
 
 @Configuration
 public class AopConfig {
 
+    @Bean
+    public TransactionAdvice transactionAdvice(PlatformTransactionManager transactionManager) {
+        return new TransactionAdvice(transactionManager);
+    }
+
+    @Bean
+    public TransactionPointcut transactionPointcut() {
+        return new TransactionPointcut();
+    }
+
+    @Bean
+    public TransactionAdvisor transactionAdvisor(TransactionPointcut pointcut, TransactionAdvice advice) {
+        return new TransactionAdvisor(pointcut, advice);
+    }
+
+    @Bean
+    public DefaultAdvisorAutoProxyCreator defaultAdvisorAutoProxyCreator() {
+        DefaultAdvisorAutoProxyCreator defaultAdvisorAutoProxyCreator = new DefaultAdvisorAutoProxyCreator();
+        defaultAdvisorAutoProxyCreator.setProxyTargetClass(true);
+        return defaultAdvisorAutoProxyCreator;
+    }
 }

--- a/study/src/test/java/aop/stage2/Stage2Test.java
+++ b/study/src/test/java/aop/stage2/Stage2Test.java
@@ -1,8 +1,8 @@
 package aop.stage2;
 
-import aop.DataAccessException;
-import aop.StubUserHistoryDao;
-import aop.domain.User;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -10,8 +10,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import aop.DataAccessException;
+import aop.StubUserHistoryDao;
+import aop.domain.User;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class Stage2Test {


### PR DESCRIPTION
안녕하세요 폴라! 벌써 마지막 미션이네요 🥹

이번 단계를 진행하면서 고민했던 포인트 하나를 공유하고자 합니다!

Q: JdbcTemplate의 queryForObject()와 같이 조회를 위한 메서드도 Connection을 DataSourceUtils로부터 얻어오는게 좋을까? 즉, 트랜잭션 관리가 필요할까? 데이터를 변경하지 않으니까 조회가 실패해도 rollback을 할 필요가 없으므로 굳이 트랜잭션으로 관리할 필요가 없지 않을까?

그리고 직접 내린 답변은 다음과 같습니다.

A: 트랜잭션1에서 데이터를 변경하고 커밋하기 전에, 트랜잭션2에서 데이터를 조회하면 트랜잭션 격리 수준에 따라 데이터의 일관성을 유지하기 위해 트랜잭션1의 변경 사항이 반영되지 않고 조회될 수 있습니다. 하지만 하나의 트랜잭션 내에서 데이터를 변경 후 조회하는 과정이 있다면, 해당 조회에서는 변경된 사항이 반영되어야 합니다. 이를 위해선 변경과 조회가 하나의 트랜잭션으로 묶여야겠지요. 그래서 조회에서도 트랜잭션이 필요하다는 결론을 내렸습니다!

이에 대한 폴라의 의견이 궁금해요!

이번에도 리뷰 잘 부탁드립니다 🙇‍♂️