### PR TITLE
test: DataSource 학습 테스트에서 설정 하드코딩 제거 및 properties 로드 적용

### DIFF
--- a/study/src/test/java/connectionpool/stage0/Stage0Test.java
+++ b/study/src/test/java/connectionpool/stage0/Stage0Test.java
@@ -2,20 +2,16 @@ package connectionpool.stage0;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.DriverManager;
-import java.sql.SQLException;
 import java.util.Properties;
+import javax.sql.DataSource;
 import org.h2.jdbcx.JdbcDataSource;
 import org.junit.jupiter.api.Test;
 
 class Stage0Test {
 
-    private static final String H2_URL = "jdbc:h2:./test";
-    private static final String USER = "sa";
-    private static final String PASSWORD = "";
     private static final String DB_PROPERTIES = "db.properties";
     private static final String PROPERTY_DB_URL = "db.url";
     private static final String PROPERTY_DB_USER = "db.user";
@@ -33,11 +29,17 @@ class Stage0Test {
      * https://docs.oracle.com/javadb/10.8.3.0/ref/rrefjdbc4_0summary.html
      */
     @Test
-    void driverManager() throws SQLException {
+    void driverManager() throws Exception {
         // Class.forName("org.h2.Driver"); // JDBC 4.0 부터 생략 가능
         // DriverManager 클래스를 활용하여 static 변수의 정보를 활용하여 h2 db에 연결한다.
-        try (final Connection connection = DriverManager.getConnection(H2_URL, USER, PASSWORD)) {
-            assertThat(connection.isValid(1)).isTrue();
+        Properties props = loadProps();
+
+        String url = props.getProperty(PROPERTY_DB_URL);
+        String user = props.getProperty(PROPERTY_DB_USER);
+        String password = props.getProperty(PROPERTY_DB_PASSWORD);
+
+        try (final Connection conn = DriverManager.getConnection(url, user, password)) {
+            assertThat(conn.isValid(1)).isTrue();
         }
     }
 
@@ -48,26 +50,39 @@ class Stage0Test {
      * 테스트 코드의 JdbcDataSource 클래스는 h2에서 제공하는 클래스다.
      *
      * DirverManager가 아닌 DataSource를 사용하는 이유
-     * - 애플리케이션 코드를 직접 수정하지 않고 properties로 디비 연결을 변경할 수 있다.
+     * - DataSource는 인터페이스이기 때문에 H2, MySQL, PostgreSQL 같은 DB 벤더별 DataSource,
+     *   혹은 HikariCP/DBCP2 같은 커넥션 풀 구현체를 코드 수정 없이 교체할 수 있다.
      * - 커넥션 풀링(Connection pooling) 또는 분산 트랜잭션은 DataSource를 통해서 사용 가능하다.
      *
      * Using a DataSource Object to Make a Connection
      * https://docs.oracle.com/en/java/javase/11/docs/api/java.sql/javax/sql/package-summary.html
      */
     @Test
-    void dataSource() throws IOException, SQLException {
-        final Properties props = new Properties();
-        try (final InputStream input = getClass().getClassLoader().getResourceAsStream(DB_PROPERTIES)) {
-            props.load(input);
-        }
+    void dataSource() throws Exception {
+        final Properties props = loadProps();
 
-        final JdbcDataSource dataSource = new JdbcDataSource();
-        dataSource.setURL(props.getProperty(PROPERTY_DB_URL));
-        dataSource.setUser(props.getProperty(PROPERTY_DB_USER));
-        dataSource.setPassword(props.getProperty(PROPERTY_DB_PASSWORD));
+        // 구현체 설정(H2)
+        final JdbcDataSource jdbcDataSource = new JdbcDataSource();
+        final String url = props.getProperty(PROPERTY_DB_URL);
+        jdbcDataSource.setURL(url);
+        final String user = props.getProperty(PROPERTY_DB_USER);
+        jdbcDataSource.setUser(user);
+        final String password = props.getProperty(PROPERTY_DB_PASSWORD);
+        jdbcDataSource.setPassword(password);
+
+        // 사용부는 인터페이스만 의존
+        final DataSource dataSource = jdbcDataSource;
 
         try (final var connection = dataSource.getConnection()) {
             assertThat(connection.isValid(1)).isTrue();
         }
+    }
+
+    private Properties loadProps() throws Exception {
+        Properties props = new Properties();
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream(DB_PROPERTIES)) {
+            props.load(in);
+        }
+        return props;
     }
 }

--- a/study/src/test/java/connectionpool/stage0/Stage0Test.java
+++ b/study/src/test/java/connectionpool/stage0/Stage0Test.java
@@ -32,14 +32,14 @@ class Stage0Test {
     void driverManager() throws Exception {
         // Class.forName("org.h2.Driver"); // JDBC 4.0 부터 생략 가능
         // DriverManager 클래스를 활용하여 static 변수의 정보를 활용하여 h2 db에 연결한다.
-        Properties props = loadProps();
+        final Properties props = loadProps();
 
-        String url = props.getProperty(PROPERTY_DB_URL);
-        String user = props.getProperty(PROPERTY_DB_USER);
-        String password = props.getProperty(PROPERTY_DB_PASSWORD);
+        final String url = props.getProperty(PROPERTY_DB_URL);
+        final String user = props.getProperty(PROPERTY_DB_USER);
+        final String password = props.getProperty(PROPERTY_DB_PASSWORD);
 
-        try (final Connection conn = DriverManager.getConnection(url, user, password)) {
-            assertThat(conn.isValid(1)).isTrue();
+        try (final Connection connection = DriverManager.getConnection(url, user, password)) {
+            assertThat(connection.isValid(1)).isTrue();
         }
     }
 
@@ -49,7 +49,7 @@ class Stage0Test {
      * 구현체는 각 vendor에서 제공한다.
      * 테스트 코드의 JdbcDataSource 클래스는 h2에서 제공하는 클래스다.
      *
-     * DirverManager가 아닌 DataSource를 사용하는 이유
+     * DriverManager가 아닌 DataSource를 사용하는 이유
      * - DataSource는 인터페이스이기 때문에 H2, MySQL, PostgreSQL 같은 DB 벤더별 DataSource,
      *   혹은 HikariCP/DBCP2 같은 커넥션 풀 구현체를 코드 수정 없이 교체할 수 있다.
      * - 커넥션 풀링(Connection pooling) 또는 분산 트랜잭션은 DataSource를 통해서 사용 가능하다.
@@ -79,8 +79,8 @@ class Stage0Test {
     }
 
     private Properties loadProps() throws Exception {
-        Properties props = new Properties();
-        try (InputStream in = getClass().getClassLoader().getResourceAsStream(DB_PROPERTIES)) {
+        final Properties props = new Properties();
+        try (final InputStream in = getClass().getClassLoader().getResourceAsStream(DB_PROPERTIES)) {
             props.load(in);
         }
         return props;

--- a/study/src/test/java/connectionpool/stage0/Stage0Test.java
+++ b/study/src/test/java/connectionpool/stage0/Stage0Test.java
@@ -1,19 +1,25 @@
 package connectionpool.stage0;
 
-import org.h2.jdbcx.JdbcDataSource;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import java.util.Properties;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.Test;
 
 class Stage0Test {
 
     private static final String H2_URL = "jdbc:h2:./test";
     private static final String USER = "sa";
     private static final String PASSWORD = "";
+    private static final String DB_PROPERTIES = "db.properties";
+    private static final String PROPERTY_DB_URL = "db.url";
+    private static final String PROPERTY_DB_USER = "db.user";
+    private static final String PROPERTY_DB_PASSWORD = "db.password";
 
     /**
      * DriverManager
@@ -49,11 +55,16 @@ class Stage0Test {
      * https://docs.oracle.com/en/java/javase/11/docs/api/java.sql/javax/sql/package-summary.html
      */
     @Test
-    void dataSource() throws SQLException {
+    void dataSource() throws IOException, SQLException {
+        final Properties props = new Properties();
+        try (final InputStream input = getClass().getClassLoader().getResourceAsStream(DB_PROPERTIES)) {
+            props.load(input);
+        }
+
         final JdbcDataSource dataSource = new JdbcDataSource();
-        dataSource.setURL(H2_URL);
-        dataSource.setUser(USER);
-        dataSource.setPassword(PASSWORD);
+        dataSource.setURL(props.getProperty(PROPERTY_DB_URL));
+        dataSource.setUser(props.getProperty(PROPERTY_DB_USER));
+        dataSource.setPassword(props.getProperty(PROPERTY_DB_PASSWORD));
 
         try (final var connection = dataSource.getConnection()) {
             assertThat(connection.isValid(1)).isTrue();

--- a/study/src/test/resources/db.properties
+++ b/study/src/test/resources/db.properties
@@ -1,0 +1,3 @@
+db.url=jdbc:h2:mem:testdb
+db.user=sa
+db.password=


### PR DESCRIPTION
학습 테스트에서 보듯이 `DriverManager` 와 달리`DataSource` 는 인터페이스이므로, 외부 설정을 기반으로 쉽게 교체 가능하다는 점이 큰 장점입니다.  

기존 테스트는 단순히 연결 여부만 확인하기 때문에,  
이번 수정에서는 **"애플리케이션 코드를 직접 수정하지 않고 DB 연결을 변경할 수 있다"** 는 
`DataSource` 의 장점을 드러내도록 개선했습니다 🙇‍♀️