### PR TITLE
transaction.Stage1Test 경로 인식 버그 수정

### DIFF
--- a/app/src/main/java/com/techcourse/support/jdbc/init/DatabasePopulatorUtils.java
+++ b/app/src/main/java/com/techcourse/support/jdbc/init/DatabasePopulatorUtils.java
@@ -1,15 +1,17 @@
 package com.techcourse.support.jdbc.init;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.sql.DataSource;
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+
+import javax.sql.DataSource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DatabasePopulatorUtils {
 
@@ -20,12 +22,12 @@ public class DatabasePopulatorUtils {
         Statement statement = null;
         try {
             final var url = DatabasePopulatorUtils.class.getClassLoader().getResource("schema.sql");
-            final var file = new File(url.getFile());
+            final var file = new File(url.toURI());
             final var sql = Files.readString(file.toPath());
             connection = dataSource.getConnection();
             statement = connection.createStatement();
             statement.execute(sql);
-        } catch (NullPointerException | IOException | SQLException e) {
+        } catch (NullPointerException | IOException | SQLException | URISyntaxException e) {
             log.error(e.getMessage(), e);
         } finally {
             try {

--- a/study/src/main/java/transaction/DatabasePopulatorUtils.java
+++ b/study/src/main/java/transaction/DatabasePopulatorUtils.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import javax.sql.DataSource;
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -20,12 +21,12 @@ public class DatabasePopulatorUtils {
         Statement statement = null;
         try {
             final var url = DatabasePopulatorUtils.class.getClassLoader().getResource("schema.sql");
-            final var file = new File(url.getFile());
+            final var file = new File(url.toURI());
             final var sql = Files.readString(file.toPath());
             connection = dataSource.getConnection();
             statement = connection.createStatement();
             statement.execute(sql);
-        } catch (NullPointerException | IOException | SQLException e) {
+        } catch (NullPointerException | IOException | SQLException | URISyntaxException e) {
             log.error(e.getMessage(), e.getCause());
         } finally {
             try {


### PR DESCRIPTION
프로젝트 경로에 한글 또는 띄어쓰기가 포함되어 있을 시 transaction Stage1Test에서 schema.sql 경로를 인식하지 못하는 문제를 수정했습니다.

```
11:40:27.144 [Test worker] ERROR transaction.DatabasePopulatorUtils -- /Users/username/%eb%82%b4%20%eb%93%9c%eb%9d%bc%ec%9d%b4%eb%b8%8c/java-jdbc/study/build/resources/main/schema.sql

// 실제 경로: /Users/username/내 드라이브/java-jdbc/study/build/resources/main/schema.sql
```