### PR TITLE
[2단계 리팩터링] 프리 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -1,8 +1,10 @@
 package com.techcourse.dao;
 
 import com.interface21.jdbc.core.JdbcTemplate;
-import com.interface21.rowmapper.RowMapper;
+import com.interface21.jdbc.preparedstatementsetter.PreparedStatementSetter;
+import com.interface21.jdbc.rowmapper.RowMapper;
 import com.techcourse.domain.User;
+import java.sql.SQLException;
 import java.util.List;
 
 public class UserDao {
@@ -85,5 +87,23 @@ public class UserDao {
         );
         Object[] params = new Object[]{account};
         return jdbcTemplate.queryForObject(sql, userRowMapper, params);
+    }
+
+    public User findByEmail(final String email) throws SQLException {
+        final String sql = """
+            SELECT id, account, password, email
+            FROM users
+            WHERE email = ?
+        """;
+        RowMapper<User> userRowMapper = rs -> new User(
+            rs.getLong("id"),
+            rs.getString("account"),
+            rs.getString("password"),
+            rs.getString("email")
+        );
+        PreparedStatementSetter preparedStatementSetter = pstmt -> {
+            pstmt.setString(1, email);
+        };
+        return jdbcTemplate.queryForObject(sql, userRowMapper, preparedStatementSetter);
     }
 }

--- a/jdbc/src/main/java/com/interface21/jdbc/DataAccessException.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/DataAccessException.java
@@ -1,0 +1,8 @@
+package com.interface21.jdbc;
+
+public class DataAccessException extends RuntimeException {
+
+    public DataAccessException(String message) {
+        super(message);
+    }
+}

--- a/jdbc/src/main/java/com/interface21/jdbc/IncorrectResultSizeException.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/IncorrectResultSizeException.java
@@ -1,0 +1,8 @@
+package com.interface21.jdbc;
+
+public class IncorrectResultSizeException extends RuntimeException {
+
+    public IncorrectResultSizeException(String message) {
+        super(message);
+    }
+}

--- a/jdbc/src/main/java/com/interface21/jdbc/ParameterBindingException.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/ParameterBindingException.java
@@ -1,0 +1,8 @@
+package com.interface21.jdbc;
+
+public class ParameterBindingException extends RuntimeException {
+
+    public ParameterBindingException(String message) {
+        super(message);
+    }
+}

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -1,5 +1,8 @@
 package com.interface21.jdbc.core;
 
+import com.interface21.jdbc.IncorrectResultSizeException;
+import com.interface21.jdbc.DataAccessException;
+import com.interface21.jdbc.ParameterBindingException;
 import com.interface21.rowmapper.RowMapper;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -36,13 +39,17 @@ public class JdbcTemplate {
             return pstmt.executeUpdate();
         } catch (SQLException exception) {
             log.error(exception.getMessage(), exception);
-            throw new RuntimeException(exception);
+            throw new DataAccessException(exception.getMessage());
         }
     }
 
-    private void setParametersToPreparedStatement(Object[] params, PreparedStatement pstmt) throws SQLException {
-        for (int i=0; i< params.length; i++) {
-            pstmt.setObject(i + 1, params[i]);
+    private void setParametersToPreparedStatement(Object[] params, PreparedStatement pstmt) {
+        try {
+            for (int i = 0; i < params.length; i++) {
+                pstmt.setObject(i + 1, params[i]);
+            }
+        } catch (SQLException exception) {
+            throw new ParameterBindingException(exception.getMessage());
         }
     }
 
@@ -64,7 +71,7 @@ public class JdbcTemplate {
             }
         } catch (SQLException exception) {
             log.error(exception.getMessage(), exception);
-            throw new RuntimeException(exception);
+            throw new DataAccessException(exception.getMessage());
         }
     }
 
@@ -88,6 +95,9 @@ public class JdbcTemplate {
         List<T> queryResult = query(sql, rowMapper, params);
         if (queryResult.isEmpty()) {
             return null;
+        }
+        if (queryResult.size() > 1) {
+            throw new IncorrectResultSizeException("검색 결과가 1개 이상입니다.");
         }
         return queryResult.getFirst();
     }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -3,7 +3,8 @@ package com.interface21.jdbc.core;
 import com.interface21.jdbc.IncorrectResultSizeException;
 import com.interface21.jdbc.DataAccessException;
 import com.interface21.jdbc.ParameterBindingException;
-import com.interface21.rowmapper.RowMapper;
+import com.interface21.jdbc.preparedstatementsetter.PreparedStatementSetter;
+import com.interface21.jdbc.rowmapper.RowMapper;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -53,6 +54,18 @@ public class JdbcTemplate {
         }
     }
 
+    public int update(String sql, PreparedStatementSetter preparedStatementSetter) {
+        try (Connection conn = dataSource.getConnection();
+            PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            log.debug("query : {}", sql);
+            preparedStatementSetter.setParameters(pstmt);
+            return pstmt.executeUpdate();
+        } catch (SQLException exception) {
+            log.error(exception.getMessage(), exception);
+            throw new DataAccessException(exception.getMessage());
+        }
+    }
+
     /**
      * SELECT 전용 메서드
      * 여러 행을 반환
@@ -83,6 +96,20 @@ public class JdbcTemplate {
         return results;
     }
 
+    public <T> List<T> query(String sql, RowMapper<T> rowMapper, PreparedStatementSetter preparedStatementSetter) {
+        try (Connection conn = dataSource.getConnection();
+            PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            log.debug("query : {}", sql);
+            preparedStatementSetter.setParameters(pstmt);
+            try (ResultSet rs = pstmt.executeQuery()) {
+                return mapResultSet(rowMapper, rs);
+            }
+        } catch (SQLException exception) {
+            log.error(exception.getMessage(), exception);
+            throw new DataAccessException(exception.getMessage());
+        }
+    }
+
     /**
      * SELECT 단건 조회 전용 메서드
      * 결과가 없을 시 null을 반환
@@ -93,6 +120,17 @@ public class JdbcTemplate {
      */
     public <T> T queryForObject(String sql, RowMapper<T> rowMapper, Object... params) {
         List<T> queryResult = query(sql, rowMapper, params);
+        if (queryResult.isEmpty()) {
+            return null;
+        }
+        if (queryResult.size() > 1) {
+            throw new IncorrectResultSizeException("검색 결과가 1개 이상입니다.");
+        }
+        return queryResult.getFirst();
+    }
+
+    public <T> T queryForObject(String sql, RowMapper<T> rowMapper, PreparedStatementSetter preparedStatementSetter) {
+        List<T> queryResult = query(sql, rowMapper, preparedStatementSetter);
         if (queryResult.isEmpty()) {
             return null;
         }

--- a/jdbc/src/main/java/com/interface21/jdbc/preparedstatementsetter/PreparedStatementSetter.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/preparedstatementsetter/PreparedStatementSetter.java
@@ -1,0 +1,9 @@
+package com.interface21.jdbc.preparedstatementsetter;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public interface PreparedStatementSetter {
+
+    void setParameters(PreparedStatement pstmt) throws SQLException;
+}

--- a/jdbc/src/main/java/com/interface21/jdbc/rowmapper/RowMapper.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/rowmapper/RowMapper.java
@@ -1,4 +1,4 @@
-package com.interface21.rowmapper;
+package com.interface21.jdbc.rowmapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;


### PR DESCRIPTION
안녕하세요 호떡~ 이번에도 잘 부탁드립니다.

사실 이번 요구 사항에서는 크게 바뀌어야 할 부분이 보이지 않아서 커스텀 예외랑 `queryForObject()` 메서드의 검증 로직만 추가했습니다.

요구 사항에서는 `PreparedStatementSetter`를 도입하라고 되어있었는데, 도입하는 것의 이점을 생각해낼 수 없어서 도입하지 않았습니다.
1. `RowMapper`은 `JdbcTemplate`가 아니라 이를 호출하는 곳에서 SQL 결과 값에 대한 정보를 주는 역할이기 때문에 정보 전달을 위한 별개의 클래스로 분리되어도 된다고 생각합니다.
2. 그러나 `PreparedStatement`의 파라미터를 바인딩하는 것은 전적으로 `JdbcTemplate` 내부에서 이루어집니다. 그래서 지금과 같이 `JdbcTemplate` 내부의 메서드를 통해서 바인딩 작업이 이루어져도 아무 문제가 없다고 생각했습니다.
3. 또한 `PreparedStatementSetter`을 도입하게 되면, 이를 생성하고 이를 활용하여 `PreparedStatement`를 바인딩하는 한 단계가 더 추가됩니다. 그래서 오히려 가독성에 안 좋다고 생각했습니다.

이런 이유가 있었습니다! 혹시 의견을 제안해 주실 부분이나 궁금한 점이 있으시다면 커멘트 남겨주세요~
감사합니다!