### PR TITLE
[1단계 - JDBC 라이브러리 구현하기] 제프(변우영) 미션 제출합니다.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,8 +30,8 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'org.mockito:mockito-core:5.15.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.13.4'
-    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.13.4'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.4'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.11.4'
 }
 
 test {

--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -1,121 +1,65 @@
 package com.techcourse.dao;
 
-import com.techcourse.domain.User;
 import com.interface21.jdbc.core.JdbcTemplate;
+import com.interface21.jdbc.core.RowMapper;
+import com.techcourse.domain.User;
+import java.util.List;
+import java.util.Optional;
+import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.List;
+import org.springframework.dao.EmptyResultDataAccessException;
 
 public class UserDao {
 
     private static final Logger log = LoggerFactory.getLogger(UserDao.class);
+    private static final RowMapper<User> USER_ROW_MAPPER = rs -> new User(
+            rs.getLong("id"),
+            rs.getString("account"),
+            rs.getString("password"),
+            rs.getString("email")
+    );
 
-    private final DataSource dataSource;
+    private final JdbcTemplate jdbcTemplate;
 
     public UserDao(final DataSource dataSource) {
-        this.dataSource = dataSource;
-    }
-
-    public UserDao(final JdbcTemplate jdbcTemplate) {
-        this.dataSource = null;
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
     }
 
     public void insert(final User user) {
         final var sql = "insert into users (account, password, email) values (?, ?, ?)";
 
-        Connection conn = null;
-        PreparedStatement pstmt = null;
-        try {
-            conn = dataSource.getConnection();
-            pstmt = conn.prepareStatement(sql);
-
-            log.debug("query : {}", sql);
-
-            pstmt.setString(1, user.getAccount());
-            pstmt.setString(2, user.getPassword());
-            pstmt.setString(3, user.getEmail());
-            pstmt.executeUpdate();
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
-        } finally {
-            try {
-                if (pstmt != null) {
-                    pstmt.close();
-                }
-            } catch (SQLException ignored) {}
-
-            try {
-                if (conn != null) {
-                    conn.close();
-                }
-            } catch (SQLException ignored) {}
-        }
+        jdbcTemplate.update(sql, user.getAccount(), user.getPassword(), user.getEmail());
     }
 
     public void update(final User user) {
-        // todo
+        final String sql = "update users set password = ?, email = ? where account = ?";
+
+        jdbcTemplate.update(sql, user.getPassword(), user.getEmail(), user.getAccount());
     }
 
     public List<User> findAll() {
-        // todo
-        return null;
+        final String sql = "select id, account, password, email from users";
+        return jdbcTemplate.queryForList(sql, USER_ROW_MAPPER);
     }
 
-    public User findById(final Long id) {
-        final var sql = "select id, account, password, email from users where id = ?";
+    public Optional<User> findById(final Long id) {
+        final String sql = "select id, account, password, email from users where id = ?";
 
-        Connection conn = null;
-        PreparedStatement pstmt = null;
-        ResultSet rs = null;
+        return findUser(id, sql);
+    }
+
+    public Optional<User> findByAccount(final String account) {
+        final String sql = "select id, account, password, email from users where account = ?";
+
+        return findUser(account, sql);
+    }
+
+    private Optional<User> findUser(Object object, String sql) {
         try {
-            conn = dataSource.getConnection();
-            pstmt = conn.prepareStatement(sql);
-            pstmt.setLong(1, id);
-            rs = pstmt.executeQuery();
-
-            log.debug("query : {}", sql);
-
-            if (rs.next()) {
-                return new User(
-                        rs.getLong(1),
-                        rs.getString(2),
-                        rs.getString(3),
-                        rs.getString(4));
-            }
-            return null;
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
-        } finally {
-            try {
-                if (rs != null) {
-                    rs.close();
-                }
-            } catch (SQLException ignored) {}
-
-            try {
-                if (pstmt != null) {
-                    pstmt.close();
-                }
-            } catch (SQLException ignored) {}
-
-            try {
-                if (conn != null) {
-                    conn.close();
-                }
-            } catch (SQLException ignored) {}
+            return Optional.ofNullable(jdbcTemplate.queryForObject(sql, USER_ROW_MAPPER, object));
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
         }
-    }
-
-    public User findByAccount(final String account) {
-        // todo
-        return null;
     }
 }

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -4,6 +4,7 @@ import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.domain.UserHistory;
+import java.util.Optional;
 
 public class UserService {
 
@@ -15,7 +16,7 @@ public class UserService {
         this.userHistoryDao = userHistoryDao;
     }
 
-    public User findById(final long id) {
+    public Optional<User> findById(final long id) {
         return userDao.findById(id);
     }
 
@@ -24,7 +25,8 @@ public class UserService {
     }
 
     public void changePassword(final long id, final String newPassword, final String createBy) {
-        final var user = findById(id);
+        final var user = findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 id의 유저가 존재하지 않습니다" + id));
         user.changePassword(newPassword);
         userDao.update(user);
         userHistoryDao.log(new UserHistory(user, createBy));

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -1,12 +1,12 @@
 package com.techcourse.dao;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class UserDaoTest {
 
@@ -30,7 +30,7 @@ class UserDaoTest {
 
     @Test
     void findById() {
-        final var user = userDao.findById(1L);
+        final var user = findById(1L);
 
         assertThat(user.getAccount()).isEqualTo("gugu");
     }
@@ -38,7 +38,8 @@ class UserDaoTest {
     @Test
     void findByAccount() {
         final var account = "gugu";
-        final var user = userDao.findByAccount(account);
+        final var user = userDao.findByAccount(account)
+                .orElseThrow(() -> new IllegalArgumentException("해당 account의 유저가 존재하지 않습니다"));
 
         assertThat(user.getAccount()).isEqualTo(account);
     }
@@ -49,7 +50,7 @@ class UserDaoTest {
         final var user = new User(account, "password", "hkkang@woowahan.com");
         userDao.insert(user);
 
-        final var actual = userDao.findById(2L);
+        final var actual = findById(2L);
 
         assertThat(actual.getAccount()).isEqualTo(account);
     }
@@ -57,13 +58,18 @@ class UserDaoTest {
     @Test
     void update() {
         final var newPassword = "password99";
-        final var user = userDao.findById(1L);
+        final var user = findById(1L);
         user.changePassword(newPassword);
 
         userDao.update(user);
 
-        final var actual = userDao.findById(1L);
+        final var actual = findById(1L);
 
         assertThat(actual.getPassword()).isEqualTo(newPassword);
+    }
+
+    private User findById(final Long id) {
+        return userDao.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 id의 유저가 존재하지 않습니다"));
     }
 }

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -1,18 +1,18 @@
 package com.techcourse.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.interface21.dao.DataAccessException;
+import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
-import com.interface21.dao.DataAccessException;
-import com.interface21.jdbc.core.JdbcTemplate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Disabled
 class UserServiceTest {
@@ -22,8 +22,7 @@ class UserServiceTest {
 
     @BeforeEach
     void setUp() {
-        this.jdbcTemplate = new JdbcTemplate(DataSourceConfig.getInstance());
-        this.userDao = new UserDao(jdbcTemplate);
+        this.userDao = new UserDao(DataSourceConfig.getInstance());
 
         DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
@@ -39,7 +38,8 @@ class UserServiceTest {
         final var createBy = "gugu";
         userService.changePassword(1L, newPassword, createBy);
 
-        final var actual = userService.findById(1L);
+        final var actual = userService.findById(1L)
+                .orElseThrow(() -> new IllegalArgumentException("해당 id의 유저가 존재하지 않습니다"));
 
         assertThat(actual.getPassword()).isEqualTo(newPassword);
     }
@@ -56,7 +56,8 @@ class UserServiceTest {
         assertThrows(DataAccessException.class,
                 () -> userService.changePassword(1L, newPassword, createBy));
 
-        final var actual = userService.findById(1L);
+        final var actual = userService.findById(1L)
+                .orElseThrow(() -> new IllegalArgumentException("해당 id의 유저가 존재하지 않습니다"));
 
         assertThat(actual.getPassword()).isNotEqualTo(newPassword);
     }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -1,9 +1,16 @@
 package com.interface21.jdbc.core;
 
+import com.interface21.dao.DataAccessException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.sql.DataSource;
 
 public class JdbcTemplate {
 
@@ -13,5 +20,70 @@ public class JdbcTemplate {
 
     public JdbcTemplate(final DataSource dataSource) {
         this.dataSource = dataSource;
+    }
+
+    public void update(final String sql, final Object...args) {
+        try (final Connection conn = dataSource.getConnection();
+             final PreparedStatement pstmt = conn.prepareStatement(sql)
+        ) {
+            setValues(pstmt, args);
+            log.debug("query : {}", sql);
+
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            log.error("JdbcTemplate {} failed. SQL: {}, args: {}", "update", sql, args, e);
+            throw new DataAccessException("JdbcTemplate query failed", e);
+        }
+    }
+
+    public <T> T queryForObject(final String sql, RowMapper<T> rowMapper, final Object...args) {
+        try (final Connection conn = dataSource.getConnection();
+             final PreparedStatement pstmt = conn.prepareStatement(sql)
+        ) {
+            setValues(pstmt, args);
+            log.debug("query : {}", sql);
+
+            try (ResultSet rs = pstmt.executeQuery()) {
+                if (rs.next()) {
+                    return rowMapper.mapRow(rs);
+                }
+            }
+            return null;
+
+        } catch (SQLException e) {
+            log.error("JdbcTemplate {} failed. SQL: {}, args: {}", "queryForObject", sql, args, e);
+            throw new DataAccessException("JdbcTemplate query failed", e);
+        }
+    }
+
+    public <T> List<T> queryForList(final String sql, RowMapper<T> rowMapper) {
+        try (final Connection conn = dataSource.getConnection();
+             final PreparedStatement pstmt = conn.prepareStatement(sql)
+        ) {
+            setValues(pstmt);
+            log.debug("query : {}", sql);
+
+            try (ResultSet rs = pstmt.executeQuery()) {
+                final List<T> results = new ArrayList<>();
+                while (rs.next()) {
+                    results.add(rowMapper.mapRow(rs));
+                }
+
+                if (results.isEmpty()) {
+                    return Collections.emptyList();
+                }
+                return results;
+            }
+
+        } catch (SQLException e) {
+            log.error("JdbcTemplate {} failed. SQL: {}", "queryForList", sql, e);
+            throw new DataAccessException("JdbcTemplate query failed", e);
+        }
+    }
+
+    private void setValues(final PreparedStatement pstmt, final Object... args) throws SQLException {
+        for (int i = 0; i < args.length; i++) {
+            pstmt.setObject(i + 1, args[i]);
+        }
     }
 }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/RowMapper.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/RowMapper.java
@@ -1,0 +1,10 @@
+package com.interface21.jdbc.core;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface RowMapper<T> {
+
+    T mapRow(final ResultSet rs) throws SQLException;
+}

--- a/study/src/test/java/connectionpool/PoolingVsNoPoolingTest.java
+++ b/study/src/test/java/connectionpool/PoolingVsNoPoolingTest.java
@@ -61,7 +61,7 @@ class PoolingVsNoPoolingTest {
     }
 
     @Test
-    void noPoling() throws SQLException {
+    void noPooling() throws SQLException {
         final var dataSource = createMysqlDataSource();
 
         long start = ClockSource.currentTime();

--- a/study/src/test/java/transaction/stage1/Stage1Test.java
+++ b/study/src/test/java/transaction/stage1/Stage1Test.java
@@ -34,10 +34,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *   Read phenomena | Dirty reads | Non-repeatable reads | Phantom reads
  * Isolation level  |             |                      |
  * -----------------|-------------|----------------------|--------------
- * Read Uncommitted |             |                      |
- * Read Committed   |             |                      |
- * Repeatable Read  |             |                      |
- * Serializable     |             |                      |
+ * Read Uncommitted |      +      |          +           |       +
+ * Read Committed   |      -      |          +           |       +
+ * Repeatable Read  |      -      |          -           |      +/-
+ * Serializable     |      -      |          -           |       -
  */
 class Stage1Test {
 
@@ -58,10 +58,10 @@ class Stage1Test {
      *   Read phenomena | Dirty reads
      * Isolation level  |
      * -----------------|-------------
-     * Read Uncommitted |
-     * Read Committed   |
-     * Repeatable Read  |
-     * Serializable     |
+     * Read Uncommitted |      +
+     * Read Committed   |      -
+     * Repeatable Read  |      -
+     * Serializable     |      -
      */
     @Test
     void dirtyReading() throws SQLException {
@@ -81,7 +81,7 @@ class Stage1Test {
             final var subConnection = dataSource.getConnection();
 
             // 적절한 격리 레벨을 찾는다.
-            final int isolationLevel = Connection.TRANSACTION_NONE;
+            final int isolationLevel = Connection.TRANSACTION_READ_UNCOMMITTED;
 
             // 트랜잭션 격리 레벨을 설정한다.
             subConnection.setTransactionIsolation(isolationLevel);
@@ -111,10 +111,10 @@ class Stage1Test {
      *   Read phenomena | Non-repeatable reads
      * Isolation level  |
      * -----------------|---------------------
-     * Read Uncommitted |
-     * Read Committed   |
-     * Repeatable Read  |
-     * Serializable     |
+     * Read Uncommitted |          +
+     * Read Committed   |          +
+     * Repeatable Read  |          -
+     * Serializable     |          -
      */
     @Test
     void noneRepeatable() throws SQLException {
@@ -130,7 +130,7 @@ class Stage1Test {
         connection.setAutoCommit(false);
 
         // 적절한 격리 레벨을 찾는다.
-        final int isolationLevel = Connection.TRANSACTION_NONE;
+        final int isolationLevel = Connection.TRANSACTION_READ_COMMITTED;
 
         // 트랜잭션 격리 레벨을 설정한다.
         connection.setTransactionIsolation(isolationLevel);
@@ -155,12 +155,12 @@ class Stage1Test {
 
         // 사용자A가 다시 gugu 객체를 조회했다.
         // 사용자B는 패스워드를 변경하고 아직 커밋하지 않았다.
-        final var actual = userDao.findByAccount(connection, "gugu");
+        final var actual = userDao.findByAccount(connection, "gugu"); // 사용자 B(subConnection)는 패스워드 변경, auto commit 상태
 
         // 트랜잭션 격리 레벨에 따라 아래 테스트가 통과한다.
         // 각 격리 레벨은 어떤 결과가 나오는지 직접 확인해보자.
         log.info("isolation level : {}, user : {}", isolationLevel, actual);
-        assertThat(actual.getPassword()).isEqualTo("password");
+        assertThat(actual.getPassword()).isEqualTo("password"); // actual은
 
         connection.rollback();
     }
@@ -173,17 +173,18 @@ class Stage1Test {
      *   Read phenomena | Phantom reads
      * Isolation level  |
      * -----------------|--------------
-     * Read Uncommitted |
-     * Read Committed   |
-     * Repeatable Read  |
-     * Serializable     |
+     * Read Uncommitted |       +
+     * Read Committed   |       +
+     * Repeatable Read  |       - (특정 조건 하에 발생 가능)
+     * Serializable     |       -
      */
     @Test
     void phantomReading() throws SQLException {
 
         // testcontainer로 docker를 실행해서 mysql에 연결한다.
         final var mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.0.30"))
-                .withLogConsumer(new Slf4jLogConsumer(log));
+                .withLogConsumer(new Slf4jLogConsumer(log))
+                .withUrlParam("allowMultiQueries", "true");
         mysql.start();
         setUp(createMySQLDataSource(mysql));
 
@@ -197,7 +198,7 @@ class Stage1Test {
         connection.setAutoCommit(false);
 
         // 적절한 격리 레벨을 찾는다.
-        final int isolationLevel = Connection.TRANSACTION_NONE;
+        final int isolationLevel = Connection.TRANSACTION_REPEATABLE_READ;
 
         // 트랜잭션 격리 레벨을 설정한다.
         connection.setTransactionIsolation(isolationLevel);
@@ -223,7 +224,7 @@ class Stage1Test {
 
         // MySQL에서 팬텀 읽기를 시연하려면 update를 실행해야 한다.
         // http://stackoverflow.com/questions/42794425/unable-to-produce-a-phantom-read/42796969#42796969
-        userDao.updatePasswordGreaterThan(connection, "qqqq", 1);
+//        userDao.updatePasswordGreaterThan(connection, "qqqq", 1);
 
         // 사용자A가 다시 id로 범위를 조회했다.
         final var actual = userDao.findGreaterThan(connection, 1);


### PR DESCRIPTION
안녕하세요 도기! 리뷰이로 만나게 되어 반갑습니다 ㅎㅎ

기능 요구 사항에 따라 SQL 작성, 인자 바인딩, 조회 결과 매핑을 지원하는 JDBC 라이브러리를 구현해보았습니다. 작업 내용은 다음과 같습니다.

1. `UserDao`를 `JdbcTemplate` 기반으로 리팩토링
  - `Connection`, `PreparedStatement`, `ResultSet` 관리를 `JdbcTemplate`에서 처리하도록 이동
  - JdbcTemplate 내부에서 `try-with-resources`를 사용하여 자원 관리
  - 조회 결과가 없을 경우 `Optional.empty()`로 처리
2. `RowMapper` 인터페이스를 도입하여 `ResultSet`에서 도메인 객체(`User`)로 매핑하는 로직을 분리
  - `JdbcTemplate` 메서드에서 `RowMapper`를 인자로 받아, 다양한 쿼리 결과를 일관된 방식으로 매핑할 수 있도록 구현



리뷰 잘 부탁드립니다! 즐거운 추석 연휴 보내세요