### PR TITLE
[3단계 - Transaction 적용하기] 돔푸(이창근) 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -1,5 +1,6 @@
 package com.techcourse.service;
 
+import com.interface21.jdbc.core.Transaction;
 import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
@@ -9,10 +10,12 @@ public class UserService {
 
     private final UserDao userDao;
     private final UserHistoryDao userHistoryDao;
+    private final Transaction transaction;
 
-    public UserService(final UserDao userDao, final UserHistoryDao userHistoryDao) {
+    public UserService(UserDao userDao, UserHistoryDao userHistoryDao, Transaction transaction) {
         this.userDao = userDao;
         this.userHistoryDao = userHistoryDao;
+        this.transaction = transaction;
     }
 
     public User findById(final long id) {
@@ -24,9 +27,16 @@ public class UserService {
     }
 
     public void changePassword(final long id, final String newPassword, final String createBy) {
-        final var user = findById(id);
-        user.changePassword(newPassword);
-        userDao.update(user);
-        userHistoryDao.log(new UserHistory(user, createBy));
+        transaction.start();
+        try {
+            final var user = findById(id);
+            user.changePassword(newPassword);
+            userDao.update(user);
+            userHistoryDao.log(new UserHistory(user, createBy));
+            transaction.commit();
+        } catch (Exception e) {
+            transaction.rollback();
+            throw e;
+        }
     }
 }

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -1,20 +1,18 @@
 package com.techcourse.service;
 
+import com.interface21.dao.DataAccessException;
+import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
-import com.interface21.dao.DataAccessException;
-import com.interface21.jdbc.core.JdbcTemplate;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@Disabled
 class UserServiceTest {
 
     private JdbcTemplate jdbcTemplate;

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -2,11 +2,13 @@ package com.techcourse.service;
 
 import com.interface21.dao.DataAccessException;
 import com.interface21.jdbc.core.JdbcTemplate;
+import com.interface21.jdbc.core.Transaction;
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
+import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -15,12 +17,15 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class UserServiceTest {
 
+    private Transaction transaction;
     private JdbcTemplate jdbcTemplate;
     private UserDao userDao;
 
     @BeforeEach
     void setUp() {
-        this.jdbcTemplate = new JdbcTemplate(DataSourceConfig.getInstance());
+        DataSource dataSource = DataSourceConfig.getInstance();
+        this.transaction = new Transaction(dataSource);
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
         this.userDao = new UserDao(jdbcTemplate);
 
         DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
@@ -31,7 +36,7 @@ class UserServiceTest {
     @Test
     void testChangePassword() {
         final var userHistoryDao = new UserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao);
+        final var userService = new UserService(userDao, userHistoryDao, transaction);
 
         final var newPassword = "qqqqq";
         final var createBy = "gugu";
@@ -46,7 +51,7 @@ class UserServiceTest {
     void testTransactionRollback() {
         // 트랜잭션 롤백 테스트를 위해 mock으로 교체
         final var userHistoryDao = new MockUserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao);
+        final var userService = new UserService(userDao, userHistoryDao, transaction);
 
         final var newPassword = "newPassword";
         final var createBy = "gugu";

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -21,9 +21,8 @@ public class JdbcTemplate {
         this.dataSource = dataSource;
     }
 
-    public void update(String sql, Object... values) {
-        try (Connection conn = dataSource.getConnection();
-             PreparedStatement pstmt = createPstmt(conn, sql, values)
+    public void update(Connection conn, String sql, Object... values) {
+        try (PreparedStatement pstmt = createPstmt(conn, sql, values)
         ) {
             pstmt.executeUpdate();
             log.debug("query : {}", sql);
@@ -33,10 +32,19 @@ public class JdbcTemplate {
         }
     }
 
-    public <T> T queryOne(String sql, ResultExtractor<T> re, Object... values) {
+    public void update(String sql, Object... values) {
+        try (Connection conn = dataSource.getConnection()
+        ) {
+            update(conn, sql, values);
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+            throw new DataAccessException(e);
+        }
+    }
+
+    public <T> T queryOne(Connection conn, String sql, ResultExtractor<T> re, Object... values) {
         ResultSet rs = null;
-        try (Connection conn = dataSource.getConnection();
-             PreparedStatement pstmt = createPstmt(conn, sql, values)
+        try (PreparedStatement pstmt = createPstmt(conn, sql, values)
         ) {
             rs = pstmt.executeQuery();
             log.debug("query : {}", sql);
@@ -51,10 +59,19 @@ public class JdbcTemplate {
         }
     }
 
-    public <T> List<T> queryMany(String sql, ResultExtractor<T> re, Object... values) {
+    public <T> T queryOne(String sql, ResultExtractor<T> re, Object... values) {
+        try (Connection conn = dataSource.getConnection()
+        ) {
+            return queryOne(conn, sql, re, values);
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+            throw new DataAccessException(e);
+        }
+    }
+
+    public <T> List<T> queryMany(Connection conn, String sql, ResultExtractor<T> re, Object... values) {
         ResultSet rs = null;
-        try (Connection conn = dataSource.getConnection();
-             PreparedStatement pstmt = createPstmt(conn, sql, values)
+        try (PreparedStatement pstmt = createPstmt(conn, sql, values)
         ) {
             rs = pstmt.executeQuery();
             log.debug("query : {}", sql);
@@ -67,6 +84,16 @@ public class JdbcTemplate {
             throw new DataAccessException(e);
         } finally {
             closeResultSet(rs);
+        }
+    }
+
+    public <T> List<T> queryMany(String sql, ResultExtractor<T> re, Object... values) {
+        try (Connection conn = dataSource.getConnection()
+        ) {
+            return queryMany(conn, sql, re, values);
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+            throw new DataAccessException(e);
         }
     }
 

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -21,31 +21,36 @@ public class JdbcTemplate {
         this.dataSource = dataSource;
     }
 
-    public void update(Connection conn, String sql, Object... values) {
-        try (PreparedStatement pstmt = createPstmt(conn, sql, values)
-        ) {
+    private void update(Connection conn, String sql, Object... values) {
+        try (PreparedStatement pstmt = createPstmt(conn, sql, values)) {
             pstmt.executeUpdate();
             log.debug("query : {}", sql);
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
+            rollbackIfManualCommit();
             throw new DataAccessException(e);
         }
     }
 
     public void update(String sql, Object... values) {
-        try (Connection conn = dataSource.getConnection()
-        ) {
+        Transaction transaction = TransactionHolder.getTransaction();
+
+        if (transaction.isStarted()) {
+            Connection conn = transaction.getConnection();
             update(conn, sql, values);
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new DataAccessException(e);
+        } else {
+            try (Connection conn = dataSource.getConnection()) {
+                update(conn, sql, values);
+            } catch (SQLException e) {
+                log.error(e.getMessage(), e);
+                throw new DataAccessException(e);
+            }
         }
     }
 
-    public <T> T queryOne(Connection conn, String sql, ResultExtractor<T> re, Object... values) {
+    private <T> T queryOne(Connection conn, String sql, ResultExtractor<T> re, Object... values) {
         ResultSet rs = null;
-        try (PreparedStatement pstmt = createPstmt(conn, sql, values)
-        ) {
+        try (PreparedStatement pstmt = createPstmt(conn, sql, values)) {
             rs = pstmt.executeQuery();
             log.debug("query : {}", sql);
 
@@ -53,6 +58,7 @@ public class JdbcTemplate {
             return null;
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
+            rollbackIfManualCommit();
             throw new DataAccessException(e);
         } finally {
             closeResultSet(rs);
@@ -60,19 +66,24 @@ public class JdbcTemplate {
     }
 
     public <T> T queryOne(String sql, ResultExtractor<T> re, Object... values) {
-        try (Connection conn = dataSource.getConnection()
-        ) {
+        Transaction transaction = TransactionHolder.getTransaction();
+
+        if (transaction.isStarted()) {
+            Connection conn = transaction.getConnection();
             return queryOne(conn, sql, re, values);
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new DataAccessException(e);
+        } else {
+            try (Connection conn = dataSource.getConnection()) {
+                return queryOne(conn, sql, re, values);
+            } catch (SQLException e) {
+                log.error(e.getMessage(), e);
+                throw new DataAccessException(e);
+            }
         }
     }
 
-    public <T> List<T> queryMany(Connection conn, String sql, ResultExtractor<T> re, Object... values) {
+    private <T> List<T> queryMany(Connection conn, String sql, ResultExtractor<T> re, Object... values) {
         ResultSet rs = null;
-        try (PreparedStatement pstmt = createPstmt(conn, sql, values)
-        ) {
+        try (PreparedStatement pstmt = createPstmt(conn, sql, values)) {
             rs = pstmt.executeQuery();
             log.debug("query : {}", sql);
 
@@ -81,6 +92,7 @@ public class JdbcTemplate {
             return results;
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
+            rollbackIfManualCommit();
             throw new DataAccessException(e);
         } finally {
             closeResultSet(rs);
@@ -88,12 +100,18 @@ public class JdbcTemplate {
     }
 
     public <T> List<T> queryMany(String sql, ResultExtractor<T> re, Object... values) {
-        try (Connection conn = dataSource.getConnection()
-        ) {
+        Transaction transaction = TransactionHolder.getTransaction();
+
+        if (transaction.isStarted()) {
+            Connection conn = transaction.getConnection();
             return queryMany(conn, sql, re, values);
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new DataAccessException(e);
+        } else {
+            try (Connection conn = dataSource.getConnection()) {
+                return queryMany(conn, sql, re, values);
+            } catch (SQLException e) {
+                log.error(e.getMessage(), e);
+                throw new DataAccessException(e);
+            }
         }
     }
 
@@ -112,5 +130,10 @@ public class JdbcTemplate {
             }
         } catch (SQLException ignored) {
         }
+    }
+
+    private static void rollbackIfManualCommit() {
+        Transaction transaction = TransactionHolder.getTransaction();
+        if (transaction.isStarted()) transaction.rollback();
     }
 }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -83,7 +83,7 @@ public class JdbcTemplate {
 
     private void runWithConnection(Consumer<Connection> consumer) {
         Transaction transaction = TransactionHolder.getTransaction();
-        if (transaction.isStarted()) {
+        if (transaction != null && transaction.isStarted()) {
             Connection conn = transaction.getConnection();
             consumer.accept(conn);
         } else {
@@ -98,7 +98,7 @@ public class JdbcTemplate {
 
     private <T> T getWithConnection(Function<Connection, T> function) {
         Transaction transaction = TransactionHolder.getTransaction();
-        if (transaction.isStarted()) {
+        if (transaction != null && transaction.isStarted()) {
             Connection conn = transaction.getConnection();
             return function.apply(conn);
         } else {

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -7,6 +7,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,19 +35,7 @@ public class JdbcTemplate {
     }
 
     public void update(String sql, Object... values) {
-        Transaction transaction = TransactionHolder.getTransaction();
-
-        if (transaction.isStarted()) {
-            Connection conn = transaction.getConnection();
-            update(conn, sql, values);
-        } else {
-            try (Connection conn = dataSource.getConnection()) {
-                update(conn, sql, values);
-            } catch (SQLException e) {
-                log.error(e.getMessage(), e);
-                throw new DataAccessException(e);
-            }
-        }
+        runWithConnection((conn) -> update(conn, sql, values));
     }
 
     private <T> T queryOne(Connection conn, String sql, ResultExtractor<T> re, Object... values) {
@@ -66,19 +56,7 @@ public class JdbcTemplate {
     }
 
     public <T> T queryOne(String sql, ResultExtractor<T> re, Object... values) {
-        Transaction transaction = TransactionHolder.getTransaction();
-
-        if (transaction.isStarted()) {
-            Connection conn = transaction.getConnection();
-            return queryOne(conn, sql, re, values);
-        } else {
-            try (Connection conn = dataSource.getConnection()) {
-                return queryOne(conn, sql, re, values);
-            } catch (SQLException e) {
-                log.error(e.getMessage(), e);
-                throw new DataAccessException(e);
-            }
-        }
+        return getWithConnection((conn) -> queryOne(conn, sql, re, values));
     }
 
     private <T> List<T> queryMany(Connection conn, String sql, ResultExtractor<T> re, Object... values) {
@@ -100,14 +78,32 @@ public class JdbcTemplate {
     }
 
     public <T> List<T> queryMany(String sql, ResultExtractor<T> re, Object... values) {
-        Transaction transaction = TransactionHolder.getTransaction();
+        return getWithConnection((conn) -> queryMany(conn, sql, re, values));
+    }
 
+    private void runWithConnection(Consumer<Connection> consumer) {
+        Transaction transaction = TransactionHolder.getTransaction();
         if (transaction.isStarted()) {
             Connection conn = transaction.getConnection();
-            return queryMany(conn, sql, re, values);
+            consumer.accept(conn);
         } else {
             try (Connection conn = dataSource.getConnection()) {
-                return queryMany(conn, sql, re, values);
+                consumer.accept(conn);
+            } catch (SQLException e) {
+                log.error(e.getMessage(), e);
+                throw new DataAccessException(e);
+            }
+        }
+    }
+
+    private <T> T getWithConnection(Function<Connection, T> function) {
+        Transaction transaction = TransactionHolder.getTransaction();
+        if (transaction.isStarted()) {
+            Connection conn = transaction.getConnection();
+            return function.apply(conn);
+        } else {
+            try (Connection conn = dataSource.getConnection()) {
+                return function.apply(conn);
             } catch (SQLException e) {
                 log.error(e.getMessage(), e);
                 throw new DataAccessException(e);

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -83,7 +83,7 @@ public class JdbcTemplate {
 
     private void runWithConnection(Consumer<Connection> consumer) {
         Transaction transaction = TransactionHolder.getTransaction();
-        if (transaction != null && transaction.isStarted()) {
+        if (transaction != null) {
             Connection conn = transaction.getConnection();
             consumer.accept(conn);
         } else {
@@ -98,7 +98,7 @@ public class JdbcTemplate {
 
     private <T> T getWithConnection(Function<Connection, T> function) {
         Transaction transaction = TransactionHolder.getTransaction();
-        if (transaction != null && transaction.isStarted()) {
+        if (transaction != null) {
             Connection conn = transaction.getConnection();
             return function.apply(conn);
         } else {
@@ -130,6 +130,6 @@ public class JdbcTemplate {
 
     private static void rollbackIfManualCommit() {
         Transaction transaction = TransactionHolder.getTransaction();
-        if (transaction.isStarted()) transaction.rollback();
+        if (transaction != null) transaction.rollback();
     }
 }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/Transaction.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/Transaction.java
@@ -3,8 +3,12 @@ package com.interface21.jdbc.core;
 import java.sql.Connection;
 import java.sql.SQLException;
 import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Transaction {
+
+    private static final Logger log = LoggerFactory.getLogger(Transaction.class);
 
     private final DataSource dataSource;
     private Connection connection;
@@ -22,6 +26,7 @@ public class Transaction {
             this.isStarted = true;
             TransactionHolder.setTransaction(this);
         } catch (SQLException e) {
+            log.error(e.getMessage(), e);
             // TODO : 예외처리 강화 필요
             throw new RuntimeException(e);
         }
@@ -30,9 +35,11 @@ public class Transaction {
     public void commit() {
         try {
             connection.commit();
+            connection.close();
             this.connection = null;
             this.isStarted = false;
         } catch (SQLException e) {
+            log.error(e.getMessage(), e);
             // TODO : 예외처리 강화 필요
             throw new RuntimeException(e);
         }
@@ -41,9 +48,11 @@ public class Transaction {
     public void rollback() {
         try {
             connection.rollback();
+            connection.close();
             this.connection = null;
             this.isStarted = false;
         } catch (SQLException e) {
+            log.error(e.getMessage(), e);
             // TODO : 예외처리 강화 필요
             throw new RuntimeException(e);
         }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/Transaction.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/Transaction.java
@@ -1,0 +1,57 @@
+package com.interface21.jdbc.core;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+
+public class Transaction {
+
+    private final DataSource dataSource;
+    private Connection connection;
+    private boolean isStarted = false;
+
+    public Transaction(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public void start() {
+        try {
+            Connection connection = dataSource.getConnection();
+            connection.setAutoCommit(false);
+            this.connection = connection;
+            this.isStarted = true;
+            TransactionHolder.setTransaction(this);
+        } catch (SQLException e) {
+            // TODO : 예외처리 강화 필요
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void commit() {
+        try {
+            connection.commit();
+            this.isStarted = false;
+        } catch (SQLException e) {
+            // TODO : 예외처리 강화 필요
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void rollback() {
+        try {
+            connection.rollback();
+            this.isStarted = false;
+        } catch (SQLException e) {
+            // TODO : 예외처리 강화 필요
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Connection getConnection() {
+        return connection;
+    }
+
+    public boolean isStarted() {
+        return isStarted;
+    }
+}

--- a/jdbc/src/main/java/com/interface21/jdbc/core/Transaction.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/Transaction.java
@@ -30,6 +30,7 @@ public class Transaction {
     public void commit() {
         try {
             connection.commit();
+            this.connection = null;
             this.isStarted = false;
         } catch (SQLException e) {
             // TODO : 예외처리 강화 필요
@@ -40,6 +41,7 @@ public class Transaction {
     public void rollback() {
         try {
             connection.rollback();
+            this.connection = null;
             this.isStarted = false;
         } catch (SQLException e) {
             // TODO : 예외처리 강화 필요

--- a/jdbc/src/main/java/com/interface21/jdbc/core/Transaction.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/Transaction.java
@@ -12,7 +12,6 @@ public class Transaction {
 
     private final DataSource dataSource;
     private Connection connection;
-    private boolean isStarted = false;
 
     public Transaction(DataSource dataSource) {
         this.dataSource = dataSource;
@@ -23,7 +22,6 @@ public class Transaction {
             Connection connection = dataSource.getConnection();
             connection.setAutoCommit(false);
             this.connection = connection;
-            this.isStarted = true;
             TransactionHolder.setTransaction(this);
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
@@ -37,7 +35,7 @@ public class Transaction {
             connection.commit();
             connection.close();
             this.connection = null;
-            this.isStarted = false;
+            TransactionHolder.setTransaction(null);
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
             // TODO : 예외처리 강화 필요
@@ -50,7 +48,7 @@ public class Transaction {
             connection.rollback();
             connection.close();
             this.connection = null;
-            this.isStarted = false;
+            TransactionHolder.setTransaction(null);
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
             // TODO : 예외처리 강화 필요
@@ -60,9 +58,5 @@ public class Transaction {
 
     public Connection getConnection() {
         return connection;
-    }
-
-    public boolean isStarted() {
-        return isStarted;
     }
 }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/TransactionHolder.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/TransactionHolder.java
@@ -1,0 +1,14 @@
+package com.interface21.jdbc.core;
+
+public class TransactionHolder {
+
+    private static Transaction transaction;
+
+    public static void setTransaction(Transaction transaction) {
+        TransactionHolder.transaction = transaction;
+    }
+
+    public static Transaction getTransaction() {
+        return transaction;
+    }
+}

--- a/jdbc/src/main/java/com/interface21/jdbc/dsl/component/DbObject.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/dsl/component/DbObject.java
@@ -1,7 +1,12 @@
 package com.interface21.jdbc.dsl.component;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 public class DbObject {
 
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    
     private final Object object;
 
     public DbObject(Object object) {
@@ -12,6 +17,9 @@ public class DbObject {
     public String toString() {
         if (object instanceof String) {
             return "'" + object + "'";
+        } else if (object instanceof LocalDateTime localDateTime) {
+            String result = DATE_TIME_FORMATTER.format(localDateTime);
+            return "'" + result + "'";
         } else {
             return object.toString();
         }


### PR DESCRIPTION
안녕하세요 모루! 이번 스텝은 좀 어려웠습니다;;
`UserServiceTest` 통과를 목표로 하였고, 코드가 좀 복잡해진 것 같아서 동작 원리도 설명드리겠습니다.

## 구현의 중심 생각

- 결국 트랜잭션은 `Connection`의 공유가 핵심이라고 생각했습니다.
- 여러 JdbcTemplate 메서드 호출 간에 `Connection`을 공유하기 위해서는 두 방법이 있었습니다.
  - `JdbcTemplate`의 파라미터로 넘겨주기
  - `ConnectionHolder`와 같은 개념을 도입하여, `JdbcTemplate`이 이를 통해 커넥션을 획득할 수 있도록 하기
- 두 방법 중에 고민하다가, 첫번째 방법은 제가 개발한 `JdbcTemplate` 라이브러리에 의존하는 수많은 다른 코드들을 수정해야되기 때문에, 현실성이 없다고 판단하였습니다.

## 구현 방법

- `Transaction` 객체는 `start()` 시 커넥션을 들고 있게 됩니다.
- `Transaction` 객체는 `TransactionHolder`를 통해 여러 객체간 공유됩니다.
- `JdbcTemplate`은 `TransactionHolder`를 참조하여, 만약 트랜잭션이 시작되었다면, 해당 커넥션을 그대로 이어 사용하게 됩니다.

**트랜잭션 사용시**
<img width="995" height="398" alt="image" src="https://github.com/user-attachments/assets/eb97aa89-bb8c-4004-98c1-8be53c0ec408" />

**트랜잭션 미사용시**
<img width="1214" height="476" alt="image" src="https://github.com/user-attachments/assets/f34017b6-906b-4830-9af6-a04cf1ffc901" />

## 리뷰해주셨으면 좋겠는 부분

DataSource나 Connection 등이 공유되면 UserService에서도 Transaction을 주입받지 않아도 되어서 더 예쁜 코드가 탄생할 것 같은데, 이건 스텝4에서 수행하는 것 같아서 일단 넘어갔습니다.
또한 먼저 큰 틀을 잡고 객체 간에 어떻게 통신할지를 중심으로 고민했습니다. 그래서 `connection#rollback()` 같은 메서드 호출하다가 예외 터졌을 때의 처리는 전혀 해주지 않았습니다.
**세세한 예외 처리 등 보다는, 큰 틀(UserService, TransactionHolder, Transaction, JdbcTemplate)에서 상호작용하는 방식에 대해서 리뷰해주시면 좋겠습니다!!**