### PR TITLE
[3단계 - Transaction 적용하기] 줄리(한승아) 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -3,6 +3,7 @@ package com.techcourse.dao;
 import com.interface21.jdbc.core.JdbcTemplate;
 import com.interface21.jdbc.core.ResultSetMapper;
 import com.techcourse.domain.User;
+import java.sql.Connection;
 import java.sql.ResultSet;
 import java.util.List;
 
@@ -22,11 +23,15 @@ public class UserDao {
     public void insert(final User user) {
         final var sql = "insert into users (account, password, email) values (?, ?, ?)";
 
+        jdbcTemplate.setCurrentConnection();
+
         jdbcTemplate.update(sql, user.getAccount(), user.getPassword(), user.getEmail());
     }
 
-    public void update(final User user) {
+    public void update(final Connection connection, final User user) {
         final var sql = "update users set password = ? where id = ?";
+
+        jdbcTemplate.setCurrentConnection(connection);
 
         jdbcTemplate.update(sql, user.getPassword(), user.getId());
     }
@@ -34,17 +39,23 @@ public class UserDao {
     public List<User> findAll() {
         final var sql = "select id, account, password, email from users";
 
+        jdbcTemplate.setCurrentConnection();
+
         return jdbcTemplate.queryMany(sql, resultSetMapper);
     }
 
     public User findById(final Long id) {
         final var sql = "select id, account, password, email from users where id = ?";
 
+        jdbcTemplate.setCurrentConnection();
+
         return jdbcTemplate.query(sql, resultSetMapper, id);
     }
 
     public User findByAccount(final String account) {
         final var sql = "select id, account, password, email from users where account = ?";
+
+        jdbcTemplate.setCurrentConnection();
 
         return jdbcTemplate.query(sql, resultSetMapper, account);
     }

--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -52,6 +52,14 @@ public class UserDao {
         return jdbcTemplate.query(sql, resultSetMapper, id);
     }
 
+    public User findById(final Connection connection, final Long id) {
+        final var sql = "select id, account, password, email from users where id = ?";
+
+        jdbcTemplate.setCurrentConnection(connection);
+
+        return jdbcTemplate.query(sql, resultSetMapper, id);
+    }
+
     public User findByAccount(final String account) {
         final var sql = "select id, account, password, email from users where account = ?";
 

--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -2,6 +2,7 @@ package com.techcourse.dao;
 
 import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.domain.UserHistory;
+import java.sql.Connection;
 
 public class UserHistoryDao {
 
@@ -11,8 +12,10 @@ public class UserHistoryDao {
         this.jdbcTemplate = jdbcTemplate;
     }
 
-    public void log(final UserHistory userHistory) {
+    public void log(final Connection connection, final UserHistory userHistory) {
         final var sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
+
+        jdbcTemplate.setCurrentConnection(connection);
 
         jdbcTemplate.update(sql, userHistory.getUserId(), userHistory.getAccount(), userHistory.getPassword(),
                 userHistory.getEmail(), userHistory.getCreatedAt(), userHistory.getCreateBy());

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -1,9 +1,13 @@
 package com.techcourse.service;
 
+import com.interface21.dao.DataAccessException;
+import com.interface21.jdbc.core.ConnectionManager;
+import com.techcourse.config.DataSourceConfig;
 import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.domain.UserHistory;
+import java.sql.Connection;
 
 public class UserService {
 
@@ -28,9 +32,21 @@ public class UserService {
     }
 
     public void changePassword(final long id, final String newPassword, final String createBy) {
-        final var user = findById(id);
-        user.changePassword(newPassword);
-        userDao.update(user);
-        userHistoryDao.log(new UserHistory(user, createBy));
+        Connection connection = null;
+        try {
+            connection = ConnectionManager.startTransaction(DataSourceConfig.getInstance());
+
+            final var user = findById(id);
+            user.changePassword(newPassword);
+            userDao.update(connection, user);
+            userHistoryDao.log(connection, new UserHistory(user, createBy));
+
+            ConnectionManager.commitTransaction(connection);
+        } catch (Exception e) {
+            if (connection != null) {
+                ConnectionManager.rollbackTransaction(connection);
+            }
+            throw new DataAccessException(e);
+        }
     }
 }

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -23,6 +23,10 @@ public class UserService {
         return userDao.findById(id);
     }
 
+    public User findById(final Connection connection, final long id) {
+        return userDao.findById(connection, id);
+    }
+
     public User findByAccount(final String account) {
         return userDao.findByAccount(account);
     }
@@ -36,7 +40,7 @@ public class UserService {
         try {
             connection = ConnectionManager.startTransaction(DataSourceConfig.getInstance());
 
-            final var user = findById(id);
+            final var user = findById(connection, id);
             user.changePassword(newPassword);
             userDao.update(connection, user);
             userHistoryDao.log(connection, new UserHistory(user, createBy));

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -61,7 +61,7 @@ class UserDaoTest {
         final var user = userDao.findById(1L);
         user.changePassword(newPassword);
 
-        userDao.update(user);
+        userDao.update(null, user);
 
         final var actual = userDao.findById(1L);
 

--- a/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
+++ b/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
@@ -1,9 +1,10 @@
 package com.techcourse.service;
 
-import com.techcourse.dao.UserHistoryDao;
-import com.techcourse.domain.UserHistory;
 import com.interface21.dao.DataAccessException;
 import com.interface21.jdbc.core.JdbcTemplate;
+import com.techcourse.dao.UserHistoryDao;
+import com.techcourse.domain.UserHistory;
+import java.sql.Connection;
 
 public class MockUserHistoryDao extends UserHistoryDao {
 
@@ -12,7 +13,7 @@ public class MockUserHistoryDao extends UserHistoryDao {
     }
 
     @Override
-    public void log(final UserHistory userHistory) {
+    public void log(final Connection connection, final UserHistory userHistory) {
         throw new DataAccessException();
     }
 }

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -1,20 +1,18 @@
 package com.techcourse.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.interface21.dao.DataAccessException;
+import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
-import com.interface21.dao.DataAccessException;
-import com.interface21.jdbc.core.JdbcTemplate;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-@Disabled
 class UserServiceTest {
 
     private JdbcTemplate jdbcTemplate;

--- a/jdbc/src/main/java/com/interface21/jdbc/core/ConnectionManager.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/ConnectionManager.java
@@ -1,0 +1,28 @@
+package com.interface21.jdbc.core;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+
+public class ConnectionManager {
+
+    public static Connection startTransaction(final DataSource dataSource) throws SQLException {
+        Connection connection = dataSource.getConnection();
+        connection.setAutoCommit(false);
+        return connection;
+    }
+
+    public static void commitTransaction(final Connection connection) throws SQLException {
+        connection.commit();
+        connection.close();
+    }
+
+    public static void rollbackTransaction(final Connection connection) {
+        try {
+            connection.rollback();
+            connection.close();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -15,9 +15,26 @@ public class JdbcTemplate {
     private static final Logger log = LoggerFactory.getLogger(JdbcTemplate.class);
 
     private final DataSource dataSource;
+    private Connection currentConnection;
 
     public JdbcTemplate(final DataSource dataSource) {
         this.dataSource = dataSource;
+    }
+
+    public void setCurrentConnection() {
+        try {
+            this.currentConnection = dataSource.getConnection();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void setCurrentConnection(final Connection connection) {
+        if (connection == null) {
+            setCurrentConnection();
+            return;
+        }
+        this.currentConnection = connection;
     }
 
     public void update(final String sql, final Object... parameters) {
@@ -52,8 +69,7 @@ public class JdbcTemplate {
     }
 
     private <T> T executeSql(final String sql, final QueryExecutor<T> queryExecutor, final Object... parameters) {
-        try (Connection conn = dataSource.getConnection();
-             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+        try (PreparedStatement pstmt = currentConnection.prepareStatement(sql)) {
             log.debug("query : {}", sql);
 
             setParameters(pstmt, parameters);


### PR DESCRIPTION
안녕하세요, 모다~! 👋

이번 3단계를 진행하면서 계속 Connection을 어떻게 Service가 직접 제어하지 않도록 할 수 있을까 고민하다가, 그 부분은 4단계 때 처리하게 되는 것 같아서 이번 단계에서는 최소한의 코드 변경만으로 트랜잭션을 적용할 수 있도록 구현해봤습니다. (4단계 때 또 많이 바뀔 것 같아서요..)

따라서 UserDAO의 메서드 중에서도 `update()`만 Connection 객체를 인자로 받도록 했고, 나중에 지우기만 하면 되도록 JdbcTemplate의 코드를 복잡하게 변경하지 않고 임시적인 기능 추가만 했습니다. 트랜잭션 단위로 묶어야 하는 changePassword 기능에 한해 Connection은 ConnectionManager를 따로 만들어서 새 Connection 생성이나 커밋, 롤백을 하도록 했습니다.

### 이번 단계 고민 포인트
- JdbcTemplate이 자체적으로 Connection을 생성하는 경우 따로 close해주지 않고 있지만, 이 부분은 4단계에서 Connection 관리 전략이 바뀌게 되니 그때 더 고민해야겠다는 생각이 들었습니다. 그래도 3단계 때 처리하는게 나을까요? 어차피 다 바뀔 로직이어서 완성도를 어디까지 잡아야할지 고민됩니다..

벌써 추석 연휴도 끝나가네요..! 모다는 충분히 재충전하셨을까요? 남은 주도 알차게 보내시고 건강한 모습으로 다시 캠퍼스에서 만나요!! ☺