### PR TITLE
[2단계 - 리펙터링] 벨로(방예혁) 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -52,7 +52,7 @@ public final class UserDao {
                 FROM users
                 WHERE id = ?
                 """;
-        return jdbcTemplate.findById(sql, (rs) -> new User(
+        return jdbcTemplate.queryForObject(sql, (rs) -> new User(
                 rs.getLong(1),
                 rs.getString(2),
                 rs.getString(3),

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -6,65 +6,94 @@ import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class UserDaoTest {
 
     private UserDao userDao;
+    private JdbcTemplate jdbcTemplate;
 
     @BeforeEach
     void setup() {
         DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
-        final JdbcTemplate jdbcTemplate = new JdbcTemplate(DataSourceConfig.getInstance());
+        jdbcTemplate = new JdbcTemplate(DataSourceConfig.getInstance());
         userDao = new UserDao(jdbcTemplate);
-        final var user = new User("gugu", "password", "hkkang@woowahan.com");
-        userDao.insert(user);
+    }
+
+    @AfterEach
+    void tearDown() {
+        jdbcTemplate.update("TRUNCATE TABLE users");
+        jdbcTemplate.update("ALTER TABLE users ALTER COLUMN id RESTART WITH 1");
     }
 
     @Test
     void findAll() {
-        final var users = userDao.findAll();
+        // given
+        userDao.insert(new User("user1", "pass1", "user1@test.com"));
+        userDao.insert(new User("user2", "pass2", "user2@test.com"));
 
-        assertThat(users).isNotEmpty();
+        // when
+        var users = userDao.findAll();
+
+        // then
+        assertThat(users).hasSize(2);
     }
 
     @Test
     void findById() {
-        final var user = userDao.findById(1L);
+        // given
+        var user = new User("gugu", "password", "gugu@test.com");
+        userDao.insert(user);
 
-        assertThat(user.getAccount()).isEqualTo("gugu");
+        // when
+        var found = userDao.findById(1L);
+
+        // then
+        assertThat(found.getAccount()).isEqualTo("gugu");
     }
 
     @Test
     void findByAccount() {
-        final var account = "gugu";
-        final var user = userDao.findByAccount(account);
+        // given
+        var account = "gugu";
+        var user = new User(account, "password", "gugu@test.com");
+        userDao.insert(user);
 
-        assertThat(user.getAccount()).isEqualTo(account);
+        // when
+        var found = userDao.findByAccount(account);
+
+        // then
+        assertThat(found.getAccount()).isEqualTo(account);
     }
 
     @Test
     void insert() {
-        final var account = "insert-gugu";
-        final var user = new User(account, "password", "hkkang@woowahan.com");
+        // given
+        var user = new User("insert-gugu", "password", "hkkang@woowahan.com");
+
+        // when
         userDao.insert(user);
 
-        final var actual = userDao.findById(2L);
-
-        assertThat(actual.getAccount()).isEqualTo(account);
+        // then
+        var found = userDao.findById(1L);
+        assertThat(found.getEmail()).isEqualTo("hkkang@woowahan.com");
     }
 
     @Test
     void update() {
-        final var newPassword = "password99";
-        final var user = userDao.findById(1L);
-        user.changePassword(newPassword);
+        // given
+        var user = new User("gugu", "oldpass", "gugu@test.com");
+        userDao.insert(user);
+        var saved = userDao.findByAccount("gugu");
 
-        userDao.update(user);
+        // when
+        saved.changePassword("newpass");
+        userDao.update(saved);
 
-        final var actual = userDao.findById(1L);
-
-        assertThat(actual.getPassword()).isEqualTo(newPassword);
+        // then
+        var updated = userDao.findByAccount("gugu");
+        assertThat(updated.getPassword()).isEqualTo("newpass");
     }
 }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -6,6 +6,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
@@ -25,14 +26,14 @@ public final class JdbcTemplate {
             final String sql,
             final Object... args
     ) {
-        try (
-                final Connection connection = dataSource.getConnection();
-                final PreparedStatement preparedStatement = createPreparedStatement(connection, sql, args)
-        ) {
-            preparedStatement.executeUpdate();
-        } catch (SQLException exception) {
-            throw new DataAccessException(exception);
-        }
+        executeUpdate(sql, args);
+    }
+
+    public int update(
+            final String sql,
+            final Object... args
+    ) {
+        return executeUpdate(sql, args);
     }
 
     public <T> List<T> findAll(
@@ -40,31 +41,13 @@ public final class JdbcTemplate {
             final RowMapper<T> rowMapper,
             final Object... args
     ) {
-        try (
-                final Connection connection = dataSource.getConnection();
-                final PreparedStatement preparedStatement = createPreparedStatement(connection, sql, args);
-                final ResultSet resultSet = preparedStatement.executeQuery()
-        ) {
-            return mapResultSetToList(resultSet, rowMapper);
-        } catch (final SQLException exception) {
-            throw new DataAccessException(exception);
-        }
-    }
-
-    public <T> T findById(
-            final String sql,
-            final RowMapper<T> rowMapper,
-            final Object... args
-    ) {
-        try (
-                final Connection connection = dataSource.getConnection();
-                final PreparedStatement preparedStatement = createPreparedStatement(connection, sql, args);
-                final ResultSet resultSet = preparedStatement.executeQuery()
-        ) {
-            return mapResultSetToObject(resultSet, rowMapper);
-        } catch (final SQLException exception) {
-            throw new DataAccessException(exception);
-        }
+        return executeQuery(sql, args, rs -> {
+            final List<T> results = new ArrayList<>();
+            while (rs.next()) {
+                results.add(rowMapper.mapRow(rs));
+            }
+            return results;
+        });
     }
 
     public <T> T queryForObject(
@@ -72,63 +55,60 @@ public final class JdbcTemplate {
             final RowMapper<T> rowMapper,
             final Object... args
     ) {
+        return executeQuery(sql, args, rs -> {
+            if (!rs.next()) {
+                throw new DataAccessException("쿼리 결과가 없습니다.");
+            }
+            final T result = rowMapper.mapRow(rs);
+            if (rs.next()) {
+                throw new DataAccessException("쿼리 결과가 2개 이상입니다. " + result);
+            }
+            return result;
+        });
+    }
+
+    private <T> T executeQuery(
+            final String sql,
+            final Object[] args,
+            final SqlFunction<ResultSet, T> mapper
+    ) {
         try (
                 final Connection connection = dataSource.getConnection();
-                final PreparedStatement preparedStatement = createPreparedStatement(connection, sql, args);
-                final ResultSet resultSet = preparedStatement.executeQuery()
+                final PreparedStatement ps = createPreparedStatement(connection, sql, args);
+                final ResultSet rs = ps.executeQuery()
         ) {
-            return mapResultSetToObject(resultSet, rowMapper);
-        } catch (final SQLException exception) {
-            throw new DataAccessException(exception);
+            return mapper.apply(rs);
+        } catch (final SQLException e) {
+            throw new DataAccessException(e);
         }
     }
 
-    public int update(
+    private int executeUpdate(
             final String sql,
             final Object... args
     ) {
         try (
                 final Connection connection = dataSource.getConnection();
-                final PreparedStatement preparedStatement = createPreparedStatement(connection, sql, args)
+                final PreparedStatement ps = createPreparedStatement(connection, sql, args)
         ) {
-            return preparedStatement.executeUpdate();
-        } catch (SQLException exception) {
-            throw new DataAccessException(exception);
+            return ps.executeUpdate();
+        } catch (final SQLException e) {
+            log.error("데이터베이스 처리 중 예외 발생", e);
+            throw new DataAccessException(e);
         }
     }
 
     private PreparedStatement createPreparedStatement(
             final Connection con,
             final String sql,
-            final Object... args
-    )
-            throws SQLException {
+            final Object[] args
+    ) throws SQLException {
         final PreparedStatement ps = con.prepareStatement(sql);
         log.debug("query : {}", sql);
+        log.trace("parameters : {}", Arrays.toString(args));
         for (int i = 0; i < args.length; i++) {
             ps.setObject(i + 1, args[i]);
         }
         return ps;
-    }
-
-    private <T> List<T> mapResultSetToList(
-            final ResultSet resultSet,
-            final RowMapper<T> rowMapper
-    ) throws SQLException {
-        final var results = new ArrayList<T>();
-        while (resultSet.next()) {
-            results.add(rowMapper.mapRow(resultSet));
-        }
-        return results;
-    }
-
-    private <T> T mapResultSetToObject(
-            final ResultSet resultSet,
-            final RowMapper<T> rowMapper
-    ) throws SQLException {
-        if (resultSet.next()) {
-            return rowMapper.mapRow(resultSet);
-        }
-        return null;
     }
 }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/SqlFunction.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/SqlFunction.java
@@ -1,0 +1,9 @@
+package com.interface21.jdbc.core;
+
+import java.sql.SQLException;
+
+@FunctionalInterface
+interface SqlFunction<T, R> {
+
+    R apply(final T t) throws SQLException;
+}

--- a/jdbc/src/test/java/com/interface21/jdbc/core/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/com/interface21/jdbc/core/JdbcTemplateTest.java
@@ -13,6 +13,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -47,6 +48,13 @@ class JdbcTemplateTest {
         final DataSource dataSource = Mockito.mock(DataSource.class);
         jdbcTemplate = new JdbcTemplate(dataSource);
         when(dataSource.getConnection()).thenReturn(connection);
+    }
+
+    @AfterEach
+    void tearDown() throws SQLException {
+        connection.close();
+        preparedStatement.close();
+        resultSet.close();
     }
 
     @DisplayName("update는 PreparedStatement에 파라미터를 설정하고 업데이트를 실행한다.")
@@ -122,35 +130,7 @@ class JdbcTemplateTest {
         );
     }
 
-    @DisplayName("findById는 단일 객체를 정확히 매핑하여 반환한다.")
-    @Test
-    void findById() throws SQLException {
-        // given
-        final String sql = """
-                SELECT account, password, email
-                FROM users
-                WHERE account = ?
-                """;
-        final TestUser user = new TestUser("gugu", "password", "gugu@email.com");
-        when(connection.prepareStatement(sql)).thenReturn(preparedStatement);
-        when(preparedStatement.executeQuery()).thenReturn(resultSet);
-        when(resultSet.next()).thenReturn(true, false);
-        when(resultSet.getString("account")).thenReturn(user.account);
-        when(resultSet.getString("password")).thenReturn(user.password);
-        when(resultSet.getString("email")).thenReturn(user.email);
-
-        // when
-        final TestUser foundUser = jdbcTemplate.findById(sql, userRowMapper, user.account);
-
-        // then
-        assertAll(
-                () -> verify(preparedStatement).setObject(1, user.account),
-                () -> assertThat(foundUser).isNotNull(),
-                () -> assertThat(foundUser.account).isEqualTo(user.account)
-        );
-    }
-
-    @DisplayName("queryForObject는 단일 값을 반환한다.")
+    @DisplayName("queryForObject는 단일 객체를 반환한다.")
     @Test
     void queryForObject() throws SQLException {
         // given
@@ -168,6 +148,69 @@ class JdbcTemplateTest {
 
         // then
         assertThat(count).isEqualTo(1L);
+    }
+
+    @DisplayName("queryForObject는 단일 유저 객체를 매핑하여 반환한다.")
+    @Test
+    void queryForObjectWithUser() throws SQLException {
+        // given
+        final String sql = """
+                SELECT account, password, email
+                FROM users
+                WHERE account = ?
+                """;
+        when(connection.prepareStatement(sql)).thenReturn(preparedStatement);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true, false);
+        when(resultSet.getString("account")).thenReturn("gugu");
+        when(resultSet.getString("password")).thenReturn("pw1");
+        when(resultSet.getString("email")).thenReturn("gugu@email.com");
+
+        // when
+        final TestUser user = jdbcTemplate.queryForObject(sql, userRowMapper, "gugu");
+
+        // then
+        assertThat(user.account).isEqualTo("gugu");
+    }
+
+    @DisplayName("queryForObject는 결과가 없으면 예외를 던진다.")
+    @Test
+    void queryForObjectWithNoResult() throws SQLException {
+        // given
+        final String sql = """
+                SELECT account, password, email
+                FROM users
+                WHERE account = ?
+                """;
+        when(connection.prepareStatement(sql)).thenReturn(preparedStatement);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> jdbcTemplate.queryForObject(sql, userRowMapper, "gugu"))
+                .isInstanceOf(DataAccessException.class)
+                .hasMessage("쿼리 결과가 없습니다.");
+    }
+
+    @DisplayName("queryForObject는 결과가 2개 이상이면 예외를 던진다.")
+    @Test
+    void queryForObjectWithMultipleResults() throws SQLException {
+        // given
+        final String sql = """
+                SELECT account, password, email
+                FROM users
+                """;
+        when(connection.prepareStatement(sql)).thenReturn(preparedStatement);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true, true, false);
+        when(resultSet.getString("account")).thenReturn("gugu");
+        when(resultSet.getString("password")).thenReturn("pw1");
+        when(resultSet.getString("email")).thenReturn("gugu@email.com");
+
+        // when & then
+        assertThatThrownBy(() -> jdbcTemplate.queryForObject(sql, userRowMapper))
+                .isInstanceOf(DataAccessException.class)
+                .hasMessageContaining("쿼리 결과가 2개 이상입니다.");
     }
 
     @DisplayName("SQLException 발생 시 DataAccessException으로 전환하여 던진다.")


### PR DESCRIPTION
안녕하세요 새로이 😄 

이전 단계에서 이미 반영된 부분이 있어 변경 규모는 크지 않습니다.  
이번에도 잘 부탁드립니다!

## 변경 사항

- queryForObject 결과 개수 검증 구현
- jdbcTemplate에서 findById 제거
- 기타 메서드 분리 및 테스트 코드 개선

## 이전 리뷰 답변

[이전 리뷰](https://github.com/woowacourse/java-jdbc/pull/975#discussion_r2409359423)

> queyrForObejct 메서드명은 벨로만의 jdbc 라이브러를 위한 네이밍을 했다라기 보다는 기존 spring jdbc 라이브러리와 유사하게 간 것 같은데 맞나요??
만약 맞다면 제 의견은 아래와 같습니다.

네, 그런 흐름으로 결정했어요.

> 지금 구현은 ResultSet의 첫 행만 반환하고 나머지는 조용히 무시합니다. 이 동작은 “정확히 1건”을 기대하는 이름 queryForObject와 의미가 불일치합니다. 스프링 JDBC의 queryForObject가 “0건이면 예외, 2건 이상이어도 예외”를 던지는 것과도 다릅니다.
>
> 따라서 단건 보장으로 구현을 개선하거나 현재 동작에 맞춰 이름을 바꾸시면 좋을 것 같아요
>
> 만약 단건 보장으로 바꾸시면 beforEach에서 메서드가 실행될 때 마다 gugu를 insert하기 때문에 예외가 발생할 것 같아요 따라서 이 부분도 고려해주시면 좋을 것 같아요

그렇네요. `queryForObject`를 **정확히 1건을 기대하는 메서드**로 수정했습니다.
결과가 없거나 여러 건일 경우 `DataAccessException`을 발생시키도록 했습니다.  
테스트 코드 또한 각 테스트마다 필요한 데이터를 직접 삽입하도록 변경해, 테스트 간 독립성을 확보했습니다.

꼼꼼한 리뷰 감사해요! 👍 👍 