### PR TITLE
[2단계 - 리팩터링] 에드(김진우) 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -33,7 +33,12 @@ public class UserDao {
 
     public int update(final User user) {
         final var sql = "update users set account = ?, password = ?, email = ? where id = ?";
-        return jdbcTemplate.update(sql, user.getAccount(), user.getPassword(), user.getEmail(), user.getId());
+        return jdbcTemplate.update(sql, pstmt -> {
+            pstmt.setString(1, user.getAccount());
+            pstmt.setString(2, user.getPassword());
+            pstmt.setString(3, user.getEmail());
+            pstmt.setLong(4, user.getId());
+        });
     }
 
     public List<User> findAll() {

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -21,11 +21,13 @@ public class JdbcTemplate {
         this.dataSource = dataSource;
     }
 
-    private <T> T execute(String sql, StatementExecutor<T> executor, Object... params) {
+    private <T> T execute(String sql, StatementExecutor<T> executor, PreparedStatementSetter pss) {
         try (Connection conn = dataSource.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
 
-            setParameters(pstmt, params);
+            if (pss != null) {
+                pss.setValues(pstmt);
+            }
             log.debug("query : {}", sql);
 
             return executor.execute(pstmt);
@@ -37,39 +39,44 @@ public class JdbcTemplate {
     }
 
     // INSERT, UPDATE, DELETE
-    //TODO: 별도의 콜백 인터페이스 구현하면 Objcet...처럼 순서에 의존하지 않아도 된다고 함. 다음 스텝에..  (2025-09-27, 토, 17:38)
+    public int update(String sql, PreparedStatementSetter pss) {
+        return execute(sql, PreparedStatement::executeUpdate, pss);
+    }
+
     public int update(String sql, Object... params) {
-        return execute(sql, PreparedStatement::executeUpdate, params);
+        return update(sql, PreparedStatementSetter.of(params));
     }
 
     // SELECT
-    public <T> List<T> query(String sql, RowMapper<T> rowMapper, Object... params) {
+    public <T> List<T> query(String sql, RowMapper<T> rowMapper, PreparedStatementSetter pss) {
         return execute(sql, pstmt -> {
             try (ResultSet rs = pstmt.executeQuery()) {
                 List<T> results = new ArrayList<>();
                 addResultSetToResults(rowMapper, rs, results);
                 return results;
             }
-        }, params);
+        }, pss);
+    }
+
+    public <T> List<T> query(String sql, RowMapper<T> rowMapper, Object... params) {
+        return query(sql, rowMapper, PreparedStatementSetter.of(params));
     }
 
     // SELECT 단일
-    public <T> T queryForObject(String sql, RowMapper<T> rowMapper, Object... params) {
-        List<T> results = query(sql, rowMapper, params);
+    public <T> T queryForObject(String sql, RowMapper<T> rowMapper, PreparedStatementSetter pss) {
+        List<T> results = query(sql, rowMapper, pss);
         validateResultsSize(results, 1);
         return results.getFirst();
+    }
+
+    public <T> T queryForObject(String sql, RowMapper<T> rowMapper, Object... params) {
+        return queryForObject(sql, rowMapper, PreparedStatementSetter.of(params));
     }
 
     private <T> void validateResultsSize(List<T> results, int expectedSize) {
         int actualSize = results.size();
         if (actualSize != expectedSize) {
             throw new IncorrectResultSizeDataAccessException(expectedSize, actualSize);
-        }
-    }
-
-    private void setParameters(PreparedStatement pstmt, Object... params) throws SQLException {
-        for (int i = 0; i < params.length; i++) {
-            pstmt.setObject(i + 1, params[i]);
         }
     }
 

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -40,6 +40,7 @@ public class JdbcTemplate {
 
     // INSERT, UPDATE, DELETE
     public int update(String sql, PreparedStatementSetter pss) {
+        pss = ensureSetter(pss);
         return execute(sql, PreparedStatement::executeUpdate, pss);
     }
 
@@ -49,6 +50,7 @@ public class JdbcTemplate {
 
     // SELECT
     public <T> List<T> query(String sql, RowMapper<T> rowMapper, PreparedStatementSetter pss) {
+        pss = ensureSetter(pss);
         return execute(sql, pstmt -> {
             try (ResultSet rs = pstmt.executeQuery()) {
                 List<T> results = new ArrayList<>();
@@ -64,6 +66,7 @@ public class JdbcTemplate {
 
     // SELECT 단일
     public <T> T queryForObject(String sql, RowMapper<T> rowMapper, PreparedStatementSetter pss) {
+        pss = ensureSetter(pss);
         List<T> results = query(sql, rowMapper, pss);
         validateResultsSize(results, 1);
         return results.getFirst();
@@ -71,6 +74,13 @@ public class JdbcTemplate {
 
     public <T> T queryForObject(String sql, RowMapper<T> rowMapper, Object... params) {
         return queryForObject(sql, rowMapper, PreparedStatementSetter.of(params));
+    }
+
+    private PreparedStatementSetter ensureSetter(PreparedStatementSetter pss) {
+        if (pss == null) {
+            pss = PreparedStatementSetter.of(null);
+        }
+        return pss;
     }
 
     private <T> void validateResultsSize(List<T> results, int expectedSize) {

--- a/jdbc/src/main/java/com/interface21/jdbc/core/PreparedStatementSetter.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/PreparedStatementSetter.java
@@ -1,0 +1,18 @@
+package com.interface21.jdbc.core;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface PreparedStatementSetter {
+
+    void setValues(PreparedStatement pstmt) throws SQLException;
+
+    static PreparedStatementSetter of(Object... params) {
+        return pstmt -> {
+            for (int i = 0; i < params.length; i++) {
+                pstmt.setObject(i + 1, params[i]);
+            }
+        };
+    }
+}


### PR DESCRIPTION
안녕하세요 링크~~ 연휴는 잘 보내셨나요 ㅎㅎ
전 너무 잘 보내서 이제서야 step2 요청을 드리게 됐어요...
막상 요구사항을 보니 대부분 step1에서 이미 만족이 되었던 것 같아
좀 더 일찍 시도해볼걸 후회가 되네요 😅

이번 스텝에서는 다음과 같은 내용을 적용해봤어요
그럼 이번 리뷰도 잘 부탁드립니다!

---

### 배경
JdbcTemplate 사용 중 PreparedStatement 파라미터가 순서에 의존하다 보니, 쿼리 변경 시 인자 순서를 잘못 맞추는 실수가 반복될 가능성이 있다고 판단했어요.
이를 개선하기 위해 PreparedStatementSetter 콜백을 도입하고, JdbcTemplate 전반에서 활용 가능하도록 리팩터링했습니다.

### 변경 내용
- PreparedStatementSetter 인터페이스 도입
- PreparedStatement를 직접 전달받아 명시적으로 setXxx를 호출할 수 있도록 변경
- 기존 varargs 기반 호출은 내부적으로 PreparedStatementSetter.of(Object...)로 감싸서 기존 코드와의 호환성 유지
- 변경 사항에 맞춰 인자수가 가장 많았던 UserDao#update 리팩토링
```java
    public int update(final User user) {
        final var sql = "update users set account = ?, password = ?, email = ? where id = ?";
        return jdbcTemplate.update(sql, pstmt -> {
            pstmt.setString(1, user.getAccount());
            pstmt.setString(2, user.getPassword());
            pstmt.setString(3, user.getEmail());
            pstmt.setLong(4, user.getId());
        });
    }
```

완전히 순서 기반을 벗어나지는 않았지만,
의미 단위로 바인딩할 수 있게 되어 인자가 많아질수록 가독성과 타입 안정성을 높일 수 있는 구조라고 생각합니다.

현재는 PreparedStatementSetter가 단일 팩토리(of(Object...))만 제공하지만,
앞으로는 NativeQuery나 QueryDSL처럼 순서 기반에서 완전히 벗어나는 방향으로 확장할 여지가 있다고 봅니다.
다만 지금 단계에서 다른 구현체들을 고려하지는 않았어요.
필요해지는 시점에 맞춰 별도 구현체나 이름 기반 매핑 방식 등을 도입할 수 있을 것 같아요.

