### PR TITLE
[2단계 - 리팩터링] 제프(변우영) 미션 제출합니다. 

### DIFF
--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -22,13 +22,14 @@ public class JdbcTemplate {
         this.dataSource = dataSource;
     }
 
-    public void update(final String sql, PreparedStatementSetter pss) {
+    public void update(final String sql, final PreparedStatementSetter pss) {
         try (final Connection conn = dataSource.getConnection();
-             final PreparedStatement pstmt = conn.prepareStatement(sql)) {
+             final PreparedStatement pstmt = conn.prepareStatement(sql)
+        ) {
             pss.setValues(pstmt);
             log.debug("query : {}", sql);
             pstmt.executeUpdate();
-        } catch (SQLException e) {
+        } catch (final SQLException e) {
             log.error("JdbcTemplate {} failed. SQL: {}", "update", sql, e);
             throw new DataAccessException("JdbcTemplate query failed", e);
         }
@@ -49,14 +50,14 @@ public class JdbcTemplate {
             pss.setValues(pstmt);
             log.debug("query : {}", sql);
 
-            try (ResultSet rs = pstmt.executeQuery()) {
+            try (final ResultSet rs = pstmt.executeQuery()) {
                 if (rs.next()) {
                     return rowMapper.mapRow(rs);
                 }
             }
             return null;
 
-        } catch (SQLException e) {
+        } catch (final SQLException e) {
             log.error("JdbcTemplate {} failed. SQL: {}", "queryForObject", sql, e);
             throw new DataAccessException("JdbcTemplate query failed", e);
         }
@@ -70,13 +71,14 @@ public class JdbcTemplate {
         });
     }
 
-    public <T> List<T> queryForList(final String sql, RowMapper<T> rowMapper) {
+    public <T> List<T> queryForList(final String sql, final RowMapper<T> rowMapper, final PreparedStatementSetter pss) {
         try (final Connection conn = dataSource.getConnection();
              final PreparedStatement pstmt = conn.prepareStatement(sql)
         ) {
+            pss.setValues(pstmt);
             log.debug("query : {}", sql);
 
-            try (ResultSet rs = pstmt.executeQuery()) {
+            try (final ResultSet rs = pstmt.executeQuery()) {
                 final List<T> results = new ArrayList<>();
                 while (rs.next()) {
                     results.add(rowMapper.mapRow(rs));
@@ -88,9 +90,21 @@ public class JdbcTemplate {
                 return results;
             }
 
-        } catch (SQLException e) {
+        } catch (final SQLException e) {
             log.error("JdbcTemplate {} failed. SQL: {}", "queryForList", sql, e);
             throw new DataAccessException("JdbcTemplate query failed", e);
         }
+    }
+
+    public <T> List<T> queryForList(final String sql, final RowMapper<T> rowMapper, final Object...args) {
+        return queryForList(sql, rowMapper, pstmt -> {
+            for (int i = 0; i < args.length; i++) {
+                pstmt.setObject(i + 1, args[i]);
+            }
+        });
+    }
+
+    public <T> List<T> queryForList(final String sql, final RowMapper<T> rowMapper) {
+        return queryForList(sql, rowMapper, pstmt -> {});
     }
 }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -22,25 +22,31 @@ public class JdbcTemplate {
         this.dataSource = dataSource;
     }
 
-    public void update(final String sql, final Object...args) {
+    public void update(final String sql, PreparedStatementSetter pss) {
         try (final Connection conn = dataSource.getConnection();
-             final PreparedStatement pstmt = conn.prepareStatement(sql)
-        ) {
-            setValues(pstmt, args);
+             final PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pss.setValues(pstmt);
             log.debug("query : {}", sql);
-
             pstmt.executeUpdate();
         } catch (SQLException e) {
-            log.error("JdbcTemplate {} failed. SQL: {}, args: {}", "update", sql, args, e);
+            log.error("JdbcTemplate {} failed. SQL: {}", "update", sql, e);
             throw new DataAccessException("JdbcTemplate query failed", e);
         }
     }
 
-    public <T> T queryForObject(final String sql, RowMapper<T> rowMapper, final Object...args) {
+    public void update(final String sql, final Object...args) {
+        update(sql, pstmt -> {
+            for (int i = 0; i < args.length; i++) {
+                pstmt.setObject(i + 1, args[i]);
+            }
+        });
+    }
+
+    public <T> T queryForObject(final String sql, final RowMapper<T> rowMapper, final PreparedStatementSetter pss) {
         try (final Connection conn = dataSource.getConnection();
              final PreparedStatement pstmt = conn.prepareStatement(sql)
         ) {
-            setValues(pstmt, args);
+            pss.setValues(pstmt);
             log.debug("query : {}", sql);
 
             try (ResultSet rs = pstmt.executeQuery()) {
@@ -51,16 +57,23 @@ public class JdbcTemplate {
             return null;
 
         } catch (SQLException e) {
-            log.error("JdbcTemplate {} failed. SQL: {}, args: {}", "queryForObject", sql, args, e);
+            log.error("JdbcTemplate {} failed. SQL: {}", "queryForObject", sql, e);
             throw new DataAccessException("JdbcTemplate query failed", e);
         }
+    }
+
+    public <T> T queryForObject(final String sql, RowMapper<T> rowMapper, final Object...args) {
+        return queryForObject(sql, rowMapper, pstmt -> {
+            for (int i = 0; i < args.length; i++) {
+                pstmt.setObject(i + 1, args[i]);
+            }
+        });
     }
 
     public <T> List<T> queryForList(final String sql, RowMapper<T> rowMapper) {
         try (final Connection conn = dataSource.getConnection();
              final PreparedStatement pstmt = conn.prepareStatement(sql)
         ) {
-            setValues(pstmt);
             log.debug("query : {}", sql);
 
             try (ResultSet rs = pstmt.executeQuery()) {
@@ -78,12 +91,6 @@ public class JdbcTemplate {
         } catch (SQLException e) {
             log.error("JdbcTemplate {} failed. SQL: {}", "queryForList", sql, e);
             throw new DataAccessException("JdbcTemplate query failed", e);
-        }
-    }
-
-    private void setValues(final PreparedStatement pstmt, final Object... args) throws SQLException {
-        for (int i = 0; i < args.length; i++) {
-            pstmt.setObject(i + 1, args[i]);
         }
     }
 }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -23,16 +23,11 @@ public class JdbcTemplate {
     }
 
     public void update(final String sql, final PreparedStatementSetter pss) {
-        try (final Connection conn = dataSource.getConnection();
-             final PreparedStatement pstmt = conn.prepareStatement(sql)
-        ) {
+        execute(sql, pstmt -> {
             pss.setValues(pstmt);
             log.debug("query : {}", sql);
-            pstmt.executeUpdate();
-        } catch (final SQLException e) {
-            log.error("JdbcTemplate {} failed. SQL: {}", "update", sql, e);
-            throw new DataAccessException("JdbcTemplate query failed", e);
-        }
+            return pstmt.executeUpdate();
+        });
     }
 
     public void update(final String sql, final Object...args) {
@@ -44,9 +39,7 @@ public class JdbcTemplate {
     }
 
     public <T> T queryForObject(final String sql, final RowMapper<T> rowMapper, final PreparedStatementSetter pss) {
-        try (final Connection conn = dataSource.getConnection();
-             final PreparedStatement pstmt = conn.prepareStatement(sql)
-        ) {
+        return execute(sql, pstmt -> {
             pss.setValues(pstmt);
             log.debug("query : {}", sql);
 
@@ -56,11 +49,7 @@ public class JdbcTemplate {
                 }
             }
             return null;
-
-        } catch (final SQLException e) {
-            log.error("JdbcTemplate {} failed. SQL: {}", "queryForObject", sql, e);
-            throw new DataAccessException("JdbcTemplate query failed", e);
-        }
+        });
     }
 
     public <T> T queryForObject(final String sql, RowMapper<T> rowMapper, final Object...args) {
@@ -72,9 +61,7 @@ public class JdbcTemplate {
     }
 
     public <T> List<T> queryForList(final String sql, final RowMapper<T> rowMapper, final PreparedStatementSetter pss) {
-        try (final Connection conn = dataSource.getConnection();
-             final PreparedStatement pstmt = conn.prepareStatement(sql)
-        ) {
+        return execute(sql, pstmt -> {
             pss.setValues(pstmt);
             log.debug("query : {}", sql);
 
@@ -89,11 +76,7 @@ public class JdbcTemplate {
                 }
                 return results;
             }
-
-        } catch (final SQLException e) {
-            log.error("JdbcTemplate {} failed. SQL: {}", "queryForList", sql, e);
-            throw new DataAccessException("JdbcTemplate query failed", e);
-        }
+        });
     }
 
     public <T> List<T> queryForList(final String sql, final RowMapper<T> rowMapper, final Object...args) {
@@ -106,5 +89,15 @@ public class JdbcTemplate {
 
     public <T> List<T> queryForList(final String sql, final RowMapper<T> rowMapper) {
         return queryForList(sql, rowMapper, pstmt -> {});
+    }
+
+    private <T> T execute(final String sql, final PreparedStatementCallBack<T> callBack) {
+        try (final Connection conn = dataSource.getConnection();
+             final PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            return callBack.processIn(pstmt);
+        } catch (final SQLException e) {
+            log.error("JdbcTemplate execution failed. SQL: {}", sql, e);
+            throw new DataAccessException("dbcTemplate execution failed for SQL: " + sql, e);
+        }
     }
 }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/PreparedStatementCallBack.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/PreparedStatementCallBack.java
@@ -1,0 +1,9 @@
+package com.interface21.jdbc.core;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public interface PreparedStatementCallBack<T> {
+
+    T processIn(final PreparedStatement pstmt) throws SQLException;
+}

--- a/jdbc/src/main/java/com/interface21/jdbc/core/PreparedStatementSetter.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/PreparedStatementSetter.java
@@ -1,0 +1,9 @@
+package com.interface21.jdbc.core;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public interface PreparedStatementSetter {
+
+    void setValues(PreparedStatement pstmt) throws SQLException;
+}

--- a/jdbc/src/main/java/com/interface21/jdbc/core/PreparedStatementSetter.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/PreparedStatementSetter.java
@@ -5,5 +5,5 @@ import java.sql.SQLException;
 
 public interface PreparedStatementSetter {
 
-    void setValues(PreparedStatement pstmt) throws SQLException;
+    void setValues(final PreparedStatement pstmt) throws SQLException;
 }


### PR DESCRIPTION
안녕하세요 도기! 추석 잘 보내셨나요
step2에서 진행해야 하는 리팩터링 요구사항을 step1에서 대부분 만족한 것 같아, 다른 방향으로 리팩터링을 좀 더 고민해보았습니다.

### 변경 사항
#### 1. `PreparedStatementSetter` 인터페이스 도입
  - 기존의 가변 인자 방식과 함께, 이번 스텝에서 `PreparedStatementSetter`를 콜백으로 사용하는 메서드를 추가했습니다.
	- 기존의 setObject()를 사용하는 방식은 타입 추론을 오로지 JDBC 드라이버에 의존합니다.
	명시적으로 타입을 지정하는 방식을 추가하여, 잠재적인 타입 추론 문제를 방지하고자 했습니다.
	
#### 2. `queryForList` 메서드 오버로딩
   - 기존엔 파라미터가 없는 정적 쿼리만 목록 조회가 가능했지만, 
        동적인 where 절을 포함한 목록 조회가 가능하도록 가변 인자를 받는 `queryForList` 메서드를 추가했습니다.
	
#### 3. `PreparedStatementCallBack` 인터페이스를 추가
  - JdbcTemplate 메서드의 자원 할당 및 해제, 예외 처리 같은 중복 코드를 execute 템플릿 메서드를 추가했습니다.
  - 실제 작업 로직은 PreparedStatementCallback을 통해 주입받도록 했습니다.
  
  
 3번 같은 경우, 코드를 읽는 사람에 따라 더 복잡하게 느껴질 수도 있을 것 같은데 도기의 생각이 궁금합니다!