### PR TITLE
[3단계 - Transaction 적용하기] 조로(김건우) 미션 제출합니다. 

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -1,8 +1,11 @@
 package com.techcourse.dao;
 
+import com.interface21.dao.DataAccessException;
 import com.interface21.jdbc.core.JdbcTemplate;
 import com.interface21.jdbc.core.RowMapper;
 import com.techcourse.domain.User;
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,6 +35,19 @@ public class UserDao {
     public void update(final User user) {
         final var sql = "update users set account = ?, password = ?, email = ? where id = ?";
         jdbcTemplate.update(sql, user.getAccount(), user.getPassword(), user.getEmail(), user.getId());
+    }
+
+    public void update(final Connection connection, final User user) {
+        final var sql = "update users set account = ?, password = ?, email = ? where id = ?";
+        try (final var ps = connection.prepareStatement(sql)) {
+            ps.setString(1, user.getAccount());
+            ps.setString(2, user.getPassword());
+            ps.setString(3, user.getEmail());
+            ps.setLong(4, user.getId());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new DataAccessException(e);
+        }
     }
 
     public List<User> findAll() {

--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -1,7 +1,11 @@
 package com.techcourse.dao;
 
+import com.interface21.dao.DataAccessException;
 import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.domain.UserHistory;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Timestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,6 +17,21 @@ public class UserHistoryDao {
 
     public UserHistoryDao(final JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public void log(final Connection connection, final UserHistory userHistory) {
+        final var sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
+        try (final var ps = connection.prepareStatement(sql)) {
+            ps.setLong(1, userHistory.getUserId());
+            ps.setString(2, userHistory.getAccount());
+            ps.setString(3, userHistory.getPassword());
+            ps.setString(4, userHistory.getEmail());
+            ps.setTimestamp(5, Timestamp.valueOf(userHistory.getCreatedAt()));
+            ps.setString(6, userHistory.getCreateBy());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new DataAccessException(e);
+        }
     }
 
     public void log(final UserHistory userHistory) {

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -1,5 +1,6 @@
 package com.techcourse.service;
 
+import com.interface21.transaction.support.TransactionManager;
 import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
@@ -9,10 +10,12 @@ public class UserService {
 
     private final UserDao userDao;
     private final UserHistoryDao userHistoryDao;
+    private final TransactionManager transactionManager;
 
-    public UserService(final UserDao userDao, final UserHistoryDao userHistoryDao) {
+    public UserService(UserDao userDao, UserHistoryDao userHistoryDao, TransactionManager transactionManager) {
         this.userDao = userDao;
         this.userHistoryDao = userHistoryDao;
+        this.transactionManager = transactionManager;
     }
 
     public User findById(final long id) {
@@ -24,9 +27,12 @@ public class UserService {
     }
 
     public void changePassword(final long id, final String newPassword, final String createBy) {
-        final var user = findById(id);
-        user.changePassword(newPassword);
-        userDao.update(user);
-        userHistoryDao.log(new UserHistory(user, createBy));
+        transactionManager.execute(connection -> {
+            final var user = findById(id);
+            user.changePassword(newPassword);
+            userDao.update(connection, user);
+            userHistoryDao.log(connection, new UserHistory(user, createBy));
+            return null;
+        });
     }
 }

--- a/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
+++ b/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
@@ -4,6 +4,7 @@ import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.UserHistory;
 import com.interface21.dao.DataAccessException;
 import com.interface21.jdbc.core.JdbcTemplate;
+import java.sql.Connection;
 
 public class MockUserHistoryDao extends UserHistoryDao {
 
@@ -13,6 +14,11 @@ public class MockUserHistoryDao extends UserHistoryDao {
 
     @Override
     public void log(final UserHistory userHistory) {
+        throw new DataAccessException();
+    }
+
+    @Override
+    public void log(final Connection connection, final UserHistory userHistory) {
         throw new DataAccessException();
     }
 }

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.techcourse.service;
 
+import com.interface21.transaction.support.TransactionManager;
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
@@ -14,16 +15,17 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@Disabled
 class UserServiceTest {
 
     private JdbcTemplate jdbcTemplate;
     private UserDao userDao;
+    private TransactionManager transactionManager;
 
     @BeforeEach
     void setUp() {
         this.jdbcTemplate = new JdbcTemplate(DataSourceConfig.getInstance());
         this.userDao = new UserDao(jdbcTemplate);
+        this.transactionManager = new TransactionManager(DataSourceConfig.getInstance());
 
         DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
@@ -33,7 +35,7 @@ class UserServiceTest {
     @Test
     void testChangePassword() {
         final var userHistoryDao = new UserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao);
+        final var userService = new UserService(userDao, userHistoryDao, transactionManager);
 
         final var newPassword = "qqqqq";
         final var createBy = "gugu";
@@ -48,7 +50,7 @@ class UserServiceTest {
     void testTransactionRollback() {
         // 트랜잭션 롤백 테스트를 위해 mock으로 교체
         final var userHistoryDao = new MockUserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao);
+        final var userService = new UserService(userDao, userHistoryDao, transactionManager);
 
         final var newPassword = "newPassword";
         final var createBy = "gugu";

--- a/jdbc/src/main/java/com/interface21/transaction/support/TransactionCallback.java
+++ b/jdbc/src/main/java/com/interface21/transaction/support/TransactionCallback.java
@@ -1,0 +1,9 @@
+package com.interface21.transaction.support;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface TransactionCallback<T> {
+    T execute(Connection connection) throws SQLException;
+}

--- a/jdbc/src/main/java/com/interface21/transaction/support/TransactionManager.java
+++ b/jdbc/src/main/java/com/interface21/transaction/support/TransactionManager.java
@@ -1,0 +1,30 @@
+package com.interface21.transaction.support;
+
+import com.interface21.dao.DataAccessException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+
+public class TransactionManager {
+    private final DataSource dataSource;
+
+    public TransactionManager(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public <T> T execute(final TransactionCallback<T> callback) {
+        try (Connection connection = dataSource.getConnection()) {
+            try {
+                connection.setAutoCommit(false);
+                T result = callback.execute(connection);
+                connection.commit();
+                return result;
+            } catch (Exception e) {
+                connection.rollback();
+                throw new DataAccessException(e.getMessage(), e);
+            }
+        } catch (SQLException e) {
+            throw new DataAccessException(e.getMessage(), e);
+        }
+    }
+}


### PR DESCRIPTION
안녕하세요~
이번 미션은 테스트 통과를 목표로 진행해서 구조가 깔끔하지는 않은 것 같습니다 😅

### TransactionManager 도입
트랜잭션의 공통 처리 로직(Connection 획득, commit, rollback, close) 캡슐화

### DAO에 Connection 파라미터 메서드 추가
하나의 트랜잭션 내에서 Dao가 동일한 Connection 객체를 공유할 수 있도록, Connection을 직접 파라미터로 받는 update() 및 log() 메서드를 추가

현재 구조에서는 트랜잭션 범위 내의 DAO 메서드들이 Connection 객체를  전달받아야 합니다. 
이 부분은 트랜잭션 동기화 미션을 진행할 때, DAO가 Connection 파라미터를 받지 않더라도 트랜잭션이 올바르게 유지되도록 개선할 예정입니다!