### PR TITLE
[3단계 - Transaction 적용하기] 밍곰(박민선) 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -71,6 +71,11 @@ public class UserDao {
         return jdbcTemplate.queryForObject(sql, getPreparedStatementSetter(id), getRowMapper());
     }
 
+    public User findById(final Connection connection, final Long id) {
+        final var sql = "select id, account, password, email from users where id = ?";
+        return jdbcTemplate.queryForObject(connection, sql, getPreparedStatementSetter(id), getRowMapper());
+    }
+
     public User findByAccount(final String account) {
         final var sql = "select id, account, password, email from users where account = ?";
         return jdbcTemplate.queryForObject(sql, getPreparedStatementSetter(account), getRowMapper());

--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
+import java.sql.Connection;
 import java.util.List;
 
 public class UserDao {
@@ -38,6 +39,19 @@ public class UserDao {
     public void update(final User user) {
         final String sql = "update users set account = ?, password = ?, email = ? where id = ?";
         jdbcTemplate.update(
+                sql,
+                getPreparedStatementSetter(
+                        user.getAccount(),
+                        user.getPassword(),
+                        user.getEmail(),
+                        user.getId()
+                ));
+    }
+
+    public void update(final Connection connection, final User user) {
+        final String sql = "update users set account = ?, password = ?, email = ? where id = ?";
+        jdbcTemplate.update(
+                connection,
                 sql,
                 getPreparedStatementSetter(
                         user.getAccount(),

--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -1,62 +1,48 @@
 package com.techcourse.dao;
 
-import com.techcourse.domain.UserHistory;
 import com.interface21.jdbc.core.JdbcTemplate;
+import com.interface21.jdbc.core.PreparedStatementSetter;
+import com.techcourse.domain.UserHistory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
 
 public class UserHistoryDao {
 
     private static final Logger log = LoggerFactory.getLogger(UserHistoryDao.class);
 
-    private final DataSource dataSource;
+    private final JdbcTemplate jdbcTemplate;
 
     public UserHistoryDao(final DataSource dataSource) {
-        this.dataSource = dataSource;
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
     }
 
     public UserHistoryDao(final JdbcTemplate jdbcTemplate) {
-        this.dataSource = null;
+        this.jdbcTemplate = jdbcTemplate;
     }
 
     public void log(final UserHistory userHistory) {
         final var sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
 
-        Connection conn = null;
-        PreparedStatement pstmt = null;
-        try {
-            conn = dataSource.getConnection();
-            pstmt = conn.prepareStatement(sql);
+        jdbcTemplate.update(sql, getPreparedStatementSetter(
+                userHistory.getUserId(),
+                userHistory.getAccount(),
+                userHistory.getPassword(),
+                userHistory.getEmail(),
+                userHistory.getCreatedAt(),
+                userHistory.getCreateBy()
+        ));
+    }
 
-            log.debug("query : {}", sql);
-
-            pstmt.setLong(1, userHistory.getUserId());
-            pstmt.setString(2, userHistory.getAccount());
-            pstmt.setString(3, userHistory.getPassword());
-            pstmt.setString(4, userHistory.getEmail());
-            pstmt.setObject(5, userHistory.getCreatedAt());
-            pstmt.setString(6, userHistory.getCreateBy());
-            pstmt.executeUpdate();
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
-        } finally {
-            try {
-                if (pstmt != null) {
-                    pstmt.close();
-                }
-            } catch (SQLException ignored) {}
-
-            try {
-                if (conn != null) {
-                    conn.close();
-                }
-            } catch (SQLException ignored) {}
-        }
+    private static PreparedStatementSetter getPreparedStatementSetter(Object... params) {
+        return (pstmt) -> {
+            if (params == null) {
+                return;
+            }
+            for (int i = 0; i < params.length; i++) {
+                pstmt.setObject(i + 1, params[i]);
+            }
+        };
     }
 }

--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -6,17 +6,13 @@ import com.techcourse.domain.UserHistory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.sql.DataSource;
+import java.sql.Connection;
 
 public class UserHistoryDao {
 
     private static final Logger log = LoggerFactory.getLogger(UserHistoryDao.class);
 
     private final JdbcTemplate jdbcTemplate;
-
-    public UserHistoryDao(final DataSource dataSource) {
-        this.jdbcTemplate = new JdbcTemplate(dataSource);
-    }
 
     public UserHistoryDao(final JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
@@ -32,6 +28,21 @@ public class UserHistoryDao {
                 userHistory.getEmail(),
                 userHistory.getCreatedAt(),
                 userHistory.getCreateBy()
+        ));
+    }
+
+    public void log(final Connection connection, final UserHistory userHistory) {
+        final var sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
+        jdbcTemplate.update(
+                connection,
+                sql,
+                getPreparedStatementSetter(
+                        userHistory.getUserId(),
+                        userHistory.getAccount(),
+                        userHistory.getPassword(),
+                        userHistory.getEmail(),
+                        userHistory.getCreatedAt(),
+                        userHistory.getCreateBy()
         ));
     }
 

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -44,7 +44,7 @@ public class UserService {
             userHistoryDao.log(connection, new UserHistory(user, createBy));
 
             connection.commit();
-        } catch (SQLException e) {
+        } catch (Exception e) {
             try {
                 connection.rollback();
             } catch (SQLException ignored) {}

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -6,12 +6,16 @@ import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.domain.UserHistory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
 
 public class UserService {
+
+    private static final Logger log = LoggerFactory.getLogger(UserService.class);
 
     private final UserDao userDao;
     private final UserHistoryDao userHistoryDao;
@@ -47,11 +51,18 @@ public class UserService {
         } catch (Exception e) {
             try {
                 connection.rollback();
-            } catch (SQLException ignored) {}
+                throw e;
+            } catch (SQLException sqlException) {
+                log.error(sqlException.getMessage(), sqlException);
+                throw new RuntimeException("failed to rollback transaction");
+            }
         } finally {
             try {
                 connection.close();
-            } catch (SQLException ignored) {}
+            } catch (SQLException sqlException) {
+                log.error(sqlException.getMessage(), sqlException);
+                throw new RuntimeException("failed to close db connection");
+            }
         }
     }
 

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -54,7 +54,7 @@ public class UserService {
             connection.commit();
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
-            throw new RuntimeException(e.getMessage());
+            throw new RuntimeException(e.getMessage(), e);
         }
     }
 

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -71,9 +71,8 @@ public class UserService {
     private void rollback(Connection connection) {
         try {
             connection.rollback();
-        } catch (SQLException sqlException) {
-            log.error(sqlException.getMessage(), sqlException);
-            throw new RuntimeException("failed to rollback transaction");
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
         }
     }
 }

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -29,6 +29,10 @@ public class UserService {
         return userDao.findById(id);
     }
 
+    public User findById(final Connection connection, final long id) {
+        return userDao.findById(connection, id);
+    }
+
     public void insert(final User user) {
         userDao.insert(user);
     }
@@ -38,7 +42,7 @@ public class UserService {
             connection.setAutoCommit(false);
 
             try {
-                final var user = findById(id);
+                final var user = findById(connection, id);
                 user.changePassword(newPassword);
                 userDao.update(connection, user);
                 userHistoryDao.log(connection, new UserHistory(user, createBy));

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -47,7 +47,7 @@ public class UserService {
                 userDao.update(connection, user);
                 userHistoryDao.log(connection, new UserHistory(user, createBy));
             } catch (Exception e) {
-                rollback(connection);
+                connection.rollback();
                 throw e;
             }
 
@@ -65,14 +65,6 @@ public class UserService {
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
             throw new CannotGetJdbcConnectionException(e.getMessage(), e);
-        }
-    }
-
-    private void rollback(Connection connection) {
-        try {
-            connection.rollback();
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
         }
     }
 }

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -47,7 +47,14 @@ public class UserService {
                 userDao.update(connection, user);
                 userHistoryDao.log(connection, new UserHistory(user, createBy));
             } catch (Exception e) {
-                connection.rollback();
+                try {
+                    connection.rollback();
+                } catch (SQLException rollbackEx) {
+                    log.error(rollbackEx.getMessage(), rollbackEx);
+                    final var ex = new RollbackFailureException("failed to rollback", rollbackEx);
+                    ex.addSuppressed(e);
+                    throw ex;
+                }
                 throw e;
             }
 
@@ -65,6 +72,12 @@ public class UserService {
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
             throw new CannotGetJdbcConnectionException(e.getMessage(), e);
+        }
+    }
+
+    public static class RollbackFailureException extends RuntimeException {
+        public RollbackFailureException(String message, Throwable cause) {
+            super(message, cause);
         }
     }
 }

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -73,15 +73,7 @@ public class UserService {
             connection.rollback();
         } catch (SQLException rollbackEx) {
             log.error(rollbackEx.getMessage(), rollbackEx);
-            final var ex = new RollbackFailureException("failed to rollback", rollbackEx);
-            ex.addSuppressed(appException);
-            throw ex;
-        }
-    }
-
-    public static class RollbackFailureException extends RuntimeException {
-        public RollbackFailureException(String message, Throwable cause) {
-            super(message, cause);
+            appException.addSuppressed(rollbackEx);
         }
     }
 }

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -1,9 +1,15 @@
 package com.techcourse.service;
 
+import com.interface21.jdbc.CannotGetJdbcConnectionException;
+import com.techcourse.config.DataSourceConfig;
 import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.domain.UserHistory;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
 
 public class UserService {
 
@@ -23,10 +29,38 @@ public class UserService {
         userDao.insert(user);
     }
 
-    public void changePassword(final long id, final String newPassword, final String createBy) {
-        final var user = findById(id);
-        user.changePassword(newPassword);
-        userDao.update(user);
-        userHistoryDao.log(new UserHistory(user, createBy));
+    public void changePassword(
+            final long id,
+            final String newPassword,
+            final String createBy
+    ) {
+        final var connection = getConnection();
+        try {
+            connection.setAutoCommit(false);
+
+            final var user = findById(id);
+            user.changePassword(newPassword);
+            userDao.update(connection, user);
+            userHistoryDao.log(connection, new UserHistory(user, createBy));
+
+            connection.commit();
+        } catch (SQLException e) {
+            try {
+                connection.rollback();
+            } catch (SQLException ignored) {}
+        } finally {
+            try {
+                connection.close();
+            } catch (SQLException ignored) {}
+        }
+    }
+
+    private Connection getConnection() {
+        final DataSource dataSource = DataSourceConfig.getInstance();
+        try {
+            return dataSource.getConnection();
+        } catch (SQLException e) {
+            throw new CannotGetJdbcConnectionException(e.getMessage(), e);
+        }
     }
 }

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -47,14 +47,7 @@ public class UserService {
                 userDao.update(connection, user);
                 userHistoryDao.log(connection, new UserHistory(user, createBy));
             } catch (Exception e) {
-                try {
-                    connection.rollback();
-                } catch (SQLException rollbackEx) {
-                    log.error(rollbackEx.getMessage(), rollbackEx);
-                    final var ex = new RollbackFailureException("failed to rollback", rollbackEx);
-                    ex.addSuppressed(e);
-                    throw ex;
-                }
+                rollback(e, connection);
                 throw e;
             }
 
@@ -72,6 +65,17 @@ public class UserService {
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
             throw new CannotGetJdbcConnectionException(e.getMessage(), e);
+        }
+    }
+
+    private void rollback(Exception appException, Connection connection) {
+        try {
+            connection.rollback();
+        } catch (SQLException rollbackEx) {
+            log.error(rollbackEx.getMessage(), rollbackEx);
+            final var ex = new RollbackFailureException("failed to rollback", rollbackEx);
+            ex.addSuppressed(appException);
+            throw ex;
         }
     }
 

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -33,36 +33,24 @@ public class UserService {
         userDao.insert(user);
     }
 
-    public void changePassword(
-            final long id,
-            final String newPassword,
-            final String createBy
-    ) {
-        final var connection = getConnection();
-        try {
+    public void changePassword(final long id, final String newPassword, final String createBy) {
+        try (final var connection = getConnection()) {
             connection.setAutoCommit(false);
 
-            final var user = findById(id);
-            user.changePassword(newPassword);
-            userDao.update(connection, user);
-            userHistoryDao.log(connection, new UserHistory(user, createBy));
+            try {
+                final var user = findById(id);
+                user.changePassword(newPassword);
+                userDao.update(connection, user);
+                userHistoryDao.log(connection, new UserHistory(user, createBy));
+            } catch (Exception e) {
+                rollback(connection);
+                throw e;
+            }
 
             connection.commit();
-        } catch (Exception e) {
-            try {
-                connection.rollback();
-                throw e;
-            } catch (SQLException sqlException) {
-                log.error(sqlException.getMessage(), sqlException);
-                throw new RuntimeException("failed to rollback transaction");
-            }
-        } finally {
-            try {
-                connection.close();
-            } catch (SQLException sqlException) {
-                log.error(sqlException.getMessage(), sqlException);
-                throw new RuntimeException("failed to close db connection");
-            }
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+            throw new RuntimeException(e.getMessage());
         }
     }
 
@@ -73,6 +61,15 @@ public class UserService {
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
             throw new CannotGetJdbcConnectionException(e.getMessage(), e);
+        }
+    }
+
+    private void rollback(Connection connection) {
+        try {
+            connection.rollback();
+        } catch (SQLException sqlException) {
+            log.error(sqlException.getMessage(), sqlException);
+            throw new RuntimeException("failed to rollback transaction");
         }
     }
 }

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -71,6 +71,7 @@ public class UserService {
         try {
             return dataSource.getConnection();
         } catch (SQLException e) {
+            log.error(e.getMessage(), e);
             throw new CannotGetJdbcConnectionException(e.getMessage(), e);
         }
     }

--- a/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
+++ b/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
@@ -5,6 +5,8 @@ import com.techcourse.domain.UserHistory;
 import com.interface21.dao.DataAccessException;
 import com.interface21.jdbc.core.JdbcTemplate;
 
+import java.sql.Connection;
+
 public class MockUserHistoryDao extends UserHistoryDao {
 
     public MockUserHistoryDao(final JdbcTemplate jdbcTemplate) {
@@ -12,7 +14,7 @@ public class MockUserHistoryDao extends UserHistoryDao {
     }
 
     @Override
-    public void log(final UserHistory userHistory) {
+    public void log(final Connection connection, final UserHistory userHistory) {
         throw new DataAccessException();
     }
 }

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -8,13 +8,11 @@ import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
 import com.interface21.dao.DataAccessException;
 import com.interface21.jdbc.core.JdbcTemplate;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@Disabled
 class UserServiceTest {
 
     private JdbcTemplate jdbcTemplate;

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -46,6 +46,17 @@ public class JdbcTemplate {
         }
     }
 
+    public int update(Connection connection, String sql, PreparedStatementSetter setter) {
+        try (final var pstmt = getPreparedStatement(sql, connection)) {
+            log.debug("query : {}", sql);
+            bindParams(sql, pstmt, setter);
+            return executeUpdate(sql, pstmt);
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+            throw new ConnectionCloseException(e, sql);
+        }
+    }
+
     @Deprecated
     public <T> List<T> query(String sql, RowMapper<T> rowMapper, Object... params) {
         return query(sql, (pstmt) -> bindParams(pstmt, params), rowMapper);

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -1,6 +1,5 @@
 package com.interface21.jdbc.core;
 
-import com.interface21.dao.DataAccessException;
 import com.interface21.jdbc.CannotGetJdbcConnectionException;
 import com.interface21.jdbc.exception.ConnectionCloseException;
 import com.interface21.jdbc.exception.ParameterBindingException;

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -88,9 +88,26 @@ public class JdbcTemplate {
         return queryForObject(sql, (pstmt) -> bindParams(pstmt, params), rowMapper);
     }
 
+    public <T> T queryForObject(Connection connection, String sql, PreparedStatementSetter setter, RowMapper<T> rowMapper) {
+        return executeQueryForObject(connection, sql, setter, rowMapper);
+    }
+
     public <T> T queryForObject(String sql, PreparedStatementSetter setter, RowMapper<T> rowMapper) {
-        try (final var conn = getConnection();
-             final var pstmt = getPreparedStatement(sql, conn)) {
+        try (final var conn = getConnection()) {
+            return executeQueryForObject(conn, sql, setter, rowMapper);
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+            throw new ConnectionCloseException(e, sql);
+        }
+    }
+
+    private <T> T executeQueryForObject(
+            final Connection conn,
+            String sql,
+            PreparedStatementSetter setter,
+            RowMapper<T> rowMapper
+    ) {
+        try (final var pstmt = getPreparedStatement(sql, conn)) {
             log.debug("query : {}", sql);
             try (final var rs = executeQuery(sql, pstmt, setter)) {
                 if (rs.next()) {

--- a/study/src/test/java/transaction/stage1/Stage1Test.java
+++ b/study/src/test/java/transaction/stage1/Stage1Test.java
@@ -172,6 +172,7 @@ class Stage1Test {
     }
 
     /**
+     * ? phantom read : 이전에 조회했을 때 보이지 않았던(or 보였던) 데이터가 이후 조회 단계에서 보이는(or 보이지 않는) 현상
      * phantom read는 h2에서 발생하지 않는다. mysql로 확인해보자.
      * 격리 수준에 따라 어떤 현상이 발생하는지 테스트를 돌려 직접 눈으로 확인하고 표를 채워보자.
      * + : 발생
@@ -179,10 +180,10 @@ class Stage1Test {
      *   Read phenomena | Phantom reads
      * Isolation level  |
      * -----------------|--------------
-     * Read Uncommitted |
-     * Read Committed   |
-     * Repeatable Read  |
-     * Serializable     |
+     * Read Uncommitted | +
+     * Read Committed   | +
+     * Repeatable Read  | +
+     * Serializable     | -
      */
     @Test
     void phantomReading() throws SQLException {
@@ -204,7 +205,7 @@ class Stage1Test {
         connection.setAutoCommit(false);
 
         // 적절한 격리 레벨을 찾는다.
-        final int isolationLevel = Connection.TRANSACTION_NONE;
+        final int isolationLevel = Connection.TRANSACTION_SERIALIZABLE; // 트랜잭션을 하나씩 순차 수행 - 팬텀 리드 발생할 일 없음
 
         // 트랜잭션 격리 레벨을 설정한다.
         connection.setTransactionIsolation(isolationLevel);
@@ -230,6 +231,11 @@ class Stage1Test {
 
         // MySQL에서 팬텀 읽기를 시연하려면 update를 실행해야 한다.
         // http://stackoverflow.com/questions/42794425/unable-to-produce-a-phantom-read/42796969#42796969
+        // why? - 추론: update를 실행하면 이전의 스냅샷을 참조하지 않고, 새로운 스냅샷을 참조할 것이다.
+        //        결과: repeatable read 를 위해 트랜잭션에서는 스냅샷을 사용함.
+        //             그런데 update / delete 는 최신 상태를 기준으로 반영해야 하므로,
+        //             update / delete 를 실행한 시점부터는 과거 스냅샷이 아닌 최신 스냅샷을 가져오게 됨.
+        //             = 내 트랜잭션에서 수행한 새로운 스냅샷 = 이후에도 그대로 참조
         userDao.updatePasswordGreaterThan(connection, "qqqq", 1);
 
         // 사용자A가 다시 id로 범위를 조회했다.

--- a/study/src/test/java/transaction/stage1/Stage1Test.java
+++ b/study/src/test/java/transaction/stage1/Stage1Test.java
@@ -189,6 +189,7 @@ class Stage1Test {
 
         // testcontainer로 docker를 실행해서 mysql에 연결한다.
         final var mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.0.30"))
+                .withUrlParam("allowMultiQueries", "true")
                 .withLogConsumer(new Slf4jLogConsumer(log));
         mysql.start();
         setUp(createMySQLDataSource(mysql));

--- a/study/src/test/java/transaction/stage1/Stage1Test.java
+++ b/study/src/test/java/transaction/stage1/Stage1Test.java
@@ -106,16 +106,17 @@ class Stage1Test {
     }
 
     /**
+     * ? non-repeatable read : 데이터를 조회하는 시점에 따라서 데이터가 변경되기 때문에, 일관된 데이터 조회 결과를 얻지 못하는 현상.
      * 격리 수준에 따라 어떤 현상이 발생하는지 테스트를 돌려 직접 눈으로 확인하고 표를 채워보자.
      * + : 발생
      * - : 발생하지 않음
      *   Read phenomena | Non-repeatable reads
      * Isolation level  |
      * -----------------|---------------------
-     * Read Uncommitted |
-     * Read Committed   |
-     * Repeatable Read  |
-     * Serializable     |
+     * Read Uncommitted | +
+     * Read Committed   | +
+     * Repeatable Read  | -
+     * Serializable     | -
      */
     @Test
     void noneRepeatable() throws SQLException {
@@ -131,7 +132,7 @@ class Stage1Test {
         connection.setAutoCommit(false);
 
         // 적절한 격리 레벨을 찾는다.
-        final int isolationLevel = Connection.TRANSACTION_NONE;
+        final int isolationLevel = Connection.TRANSACTION_REPEATABLE_READ; // 하나의 트랜잭션 내부에서 반복 조회를 하더라도 일관성을 보장
 
         // 트랜잭션 격리 레벨을 설정한다.
         connection.setTransactionIsolation(isolationLevel);
@@ -161,6 +162,10 @@ class Stage1Test {
         // 트랜잭션 격리 레벨에 따라 아래 테스트가 통과한다.
         // 각 격리 레벨은 어떤 결과가 나오는지 직접 확인해보자.
         log.info("isolation level : {}, user : {}", isolationLevel, actual);
+        // READ UNCOMMITTED - FAILED
+        // READ COMMITTED - FAILED
+        // REPEATABLE READ - SUCCESS
+        // SERIALIZABLE - SUCCESS
         assertThat(actual.getPassword()).isEqualTo("password");
 
         connection.rollback();

--- a/study/src/test/java/transaction/stage1/Stage1Test.java
+++ b/study/src/test/java/transaction/stage1/Stage1Test.java
@@ -52,16 +52,17 @@ class Stage1Test {
     }
 
     /**
+     * ? dirty read = 커밋되지 않은 내역을 읽어오는 것. 롤백될 가능성이 있는 데이터를 읽어오므로 dirty read 라고 함
      * 격리 수준에 따라 어떤 현상이 발생하는지 테스트를 돌려 직접 눈으로 확인하고 표를 채워보자.
      * + : 발생
      * - : 발생하지 않음
      *   Read phenomena | Dirty reads
      * Isolation level  |
      * -----------------|-------------
-     * Read Uncommitted |
-     * Read Committed   |
-     * Repeatable Read  |
-     * Serializable     |
+     * Read Uncommitted | +
+     * Read Committed   | -
+     * Repeatable Read  | -
+     * Serializable     | -
      */
     @Test
     void dirtyReading() throws SQLException {
@@ -81,7 +82,7 @@ class Stage1Test {
             final var subConnection = dataSource.getConnection();
 
             // 적절한 격리 레벨을 찾는다.
-            final int isolationLevel = Connection.TRANSACTION_NONE;
+            final int isolationLevel = Connection.TRANSACTION_READ_UNCOMMITTED; // -> Dirty Read 발생
 
             // 트랜잭션 격리 레벨을 설정한다.
             subConnection.setTransactionIsolation(isolationLevel);

--- a/study/src/test/java/transaction/stage2/FirstUserService.java
+++ b/study/src/test/java/transaction/stage2/FirstUserService.java
@@ -66,7 +66,7 @@ public class FirstUserService {
         throw new RuntimeException();
     }
 
-//    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithSupports() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());
@@ -77,7 +77,7 @@ public class FirstUserService {
         return of(firstTransactionName, secondTransactionName);
     }
 
-//    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithMandatory() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());
@@ -99,7 +99,7 @@ public class FirstUserService {
         return of(firstTransactionName, secondTransactionName);
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
+//    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithNested() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());
@@ -110,7 +110,7 @@ public class FirstUserService {
         return of(firstTransactionName, secondTransactionName);
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
+//    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithNever() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());

--- a/study/src/test/java/transaction/stage2/Stage2Test.java
+++ b/study/src/test/java/transaction/stage2/Stage2Test.java
@@ -37,7 +37,7 @@ class Stage2Test {
 
     /**
      * 생성된 트랜잭션이 몇 개인가?
-     * 왜 그런 결과가 나왔을까?
+     * 왜 그런 결과가 나왔을까? - 트랜잭션 전파가 적용되어 secondUserService 는 자신을 호출한 firstUserService 의 트랜잭션을 그대로 사용함
      */
     @Test
     void testRequired() {
@@ -45,13 +45,13 @@ class Stage2Test {
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(1)
+                .containsExactly("transaction.stage2.FirstUserService.saveFirstTransactionWithRequired");
     }
 
     /**
      * 생성된 트랜잭션이 몇 개인가?
-     * 왜 그런 결과가 나왔을까?
+     * 왜 그런 결과가 나왔을까? - secondUserService 는 호출부의 트랜잭션을 사용하지 않고, 새로운 트랜잭션을 생성/사용함
      */
     @Test
     void testRequiredNew() {
@@ -59,8 +59,8 @@ class Stage2Test {
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(2)
+                .containsExactly("transaction.stage2.SecondUserService.saveSecondTransactionWithRequiresNew", "transaction.stage2.FirstUserService.saveFirstTransactionWithRequiredNew");
     }
 
     /**
@@ -69,17 +69,18 @@ class Stage2Test {
      */
     @Test
     void testRequiredNewWithRollback() {
-        assertThat(firstUserService.findAll()).hasSize(-1);
+        assertThat(firstUserService.findAll()).hasSize(0);
 
         assertThatThrownBy(() -> firstUserService.saveAndExceptionWithRequiredNew())
                 .isInstanceOf(RuntimeException.class);
 
-        assertThat(firstUserService.findAll()).hasSize(-1);
+        assertThat(firstUserService.findAll()).hasSize(1); // required new 로 실행된 secondUserService 는 정상 실행됨 -> 커밋 성공
     }
 
     /**
      * FirstUserService.saveFirstTransactionWithSupports() 메서드를 보면 @Transactional이 주석으로 되어 있다.
      * 주석인 상태에서 테스트를 실행했을 때와 주석을 해제하고 테스트를 실행했을 때 어떤 차이점이 있는지 확인해보자.
+     * 결과: Support - 이미 트랜잭션이 존재하면 해당 트랜잭션을 그대로 사용 / 존재하지 않는다면 비 트랜잭션
      */
     @Test
     void testSupports() {
@@ -87,14 +88,18 @@ class Stage2Test {
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(1)
+                // 객체 명은 포함되지만, 실제로는 물리 트랜잭션이 활성화되는 것은 아님
+                .containsExactly("transaction.stage2.SecondUserService.saveSecondTransactionWithSupports");
     }
 
     /**
+     * ? Mandatory: 필수적인
      * FirstUserService.saveFirstTransactionWithMandatory() 메서드를 보면 @Transactional이 주석으로 되어 있다.
      * 주석인 상태에서 테스트를 실행했을 때와 주석을 해제하고 테스트를 실행했을 때 어떤 차이점이 있는지 확인해보자.
      * SUPPORTS와 어떤 점이 다른지도 같이 챙겨보자.
+     * 결과 - firstUserService 에 트랜잭션이 "존재하지 않는 경우 예외 발생"
+     *     - firstUserService 에 트랜잭션이 존재하는 경우 해당 트랜잭션을 그대로 사용 (= Support 와 유사하게 동작)
      */
     @Test
     void testMandatory() {
@@ -102,16 +107,19 @@ class Stage2Test {
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(1)
+                .containsExactly("transaction.stage2.FirstUserService.saveFirstTransactionWithMandatory");
     }
 
     /**
-     * 아래 테스트는 몇 개의 물리적 트랜잭션이 동작할까?
+     * 아래 테스트는 몇 개의 물리적 트랜잭션이 동작할까? - 1개
      * FirstUserService.saveFirstTransactionWithNotSupported() 메서드의 @Transactional을 주석 처리하자.
-     * 다시 테스트를 실행하면 몇 개의 물리적 트랜잭션이 동작할까?
+     * 다시 테스트를 실행하면 몇 개의 물리적 트랜잭션이 동작할까? - 0개
      *
      * 스프링 공식 문서에서 물리적 트랜잭션과 논리적 트랜잭션의 차이점이 무엇인지 찾아보자.
+     *      - 물리적 트랜잭션: 실제 DB에서 인식하는 트랜잭션 (ex. BEGIN COMMIT)
+     *      - 논리적 트랜잭션: 스프링에서의 트랜잭션 (주로 메서드 단위로 존재)
+     * 결과 - 외부 트랜잭션 존재 유무와 무관하게 항상 비 트랜잭션으로 실행된다.
      */
     @Test
     void testNotSupported() {
@@ -119,13 +127,15 @@ class Stage2Test {
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(2)
+                .containsExactly("transaction.stage2.SecondUserService.saveSecondTransactionWithNotSupported", "transaction.stage2.FirstUserService.saveFirstTransactionWithNotSupported");
     }
 
     /**
-     * 아래 테스트는 왜 실패할까?
-     * FirstUserService.saveFirstTransactionWithNested() 메서드의 @Transactional을 주석 처리하면 어떻게 될까?
+     * 아래 테스트는 왜 실패할까? - JPA 트랜잭션 매니저는 Nested 의 save point 를 지원하지 않기 때문.
+     *                      - NESTED: 외부 트랜잭션이 존재하는 경우, save point 를 만들어서 중첩 트랜잭션을 시도함
+     * FirstUserService.saveFirstTransactionWithNested() 메서드의 @Transactional을 주석 처리하면 어떻게 될까? - 성공
+     *                      - NESTED: 외부 트랜잭션이 존재하지 않으면 save point / 중첩 없이 단순히 새로운 트랜잭션을 시작함
      */
     @Test
     void testNested() {
@@ -133,12 +143,13 @@ class Stage2Test {
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(1)
+                .containsExactly("transaction.stage2.SecondUserService.saveSecondTransactionWithNested");
     }
 
     /**
      * 마찬가지로 @Transactional을 주석처리하면서 관찰해보자.
+     * 결과 - NEVER 는 비 트랜잭션 환경을 강제하는 옵션. 외부 트랜잭션이 존재하는 경우 예외가 발생함
      */
     @Test
     void testNever() {


### PR DESCRIPTION
안녕하세요 가이온!

이번 단계는 메서드 분리와 `UserServiceTest`의 테스트가 통과하는 것에만 집중해서 진행했어요~
> 4단계 키워드가 AOP 인 것으로 보아 트랜잭션 로직은 다음 단계에서 분리할 듯 싶어서 이 이상으로 진행하진 않았습니다!

이번 단계에서 고민했던 부분은 _"`Connection`을 어디서 설정하고 전달해야 할지"_ 였는데요!
**트랜잭션 적용 여부에 따라서 커넥션 공유 여부를 선택할 수 있도록**, `DAO` 및 `JdbcTemplate`의 기존 메서드를 직접 수정하지 않고 **메서드 오버로딩**을 통해 요구사항을 구현했습니다!
> `JdbcTemplate#update` 메서드는 사용자의 요구에 따라서 **직접 커넥션을 지정하여** 쿼리를 실행할 수도 있고, **새로운 커넥션으로** 쿼리를 실행할 수도 있음