### PR TITLE
[3단계 - Transaction 적용하기] 피글렛(김은수) 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -3,7 +3,7 @@ package com.techcourse.dao;
 import com.interface21.jdbc.core.JdbcTemplate;
 import com.interface21.jdbc.core.RowMapper;
 import com.techcourse.domain.User;
-import java.sql.SQLException;
+import java.sql.Connection;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,6 +35,14 @@ public class UserDao {
         jdbcTemplate.update(sql, user.getPassword(), user.getEmail(), user.getId());
     }
 
+    /*
+    Connection 공유 버전 overloading
+     */
+    public void update(final Connection connection, final User user) {
+        final var sql = "update users set password = ?, email = ? where id = ?";
+        jdbcTemplate.update(connection, sql, user.getPassword(), user.getEmail(), user.getId());
+    }
+
     public List<User> findAll() {
         final var sql = "select id, account, password, email from users";
         return jdbcTemplate.query(sql, USER_ROW_MAPPER);
@@ -42,19 +50,11 @@ public class UserDao {
 
     public User findById(final Long id) {
         final var sql = "select id, account, password, email from users where id = ?";
-        try {
-            return jdbcTemplate.queryForObject(sql, USER_ROW_MAPPER, id);
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
+        return jdbcTemplate.queryForObject(sql, USER_ROW_MAPPER, id);
     }
 
     public User findByAccount(final String account) {
         final var sql = "select id, account, password, email from users where account = ?";
-        try {
-            return jdbcTemplate.queryForObject(sql, USER_ROW_MAPPER, account);
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
+        return jdbcTemplate.queryForObject(sql, USER_ROW_MAPPER, account);
     }
 }

--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -2,6 +2,7 @@ package com.techcourse.dao;
 
 import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.domain.UserHistory;
+import java.sql.Connection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,6 +19,22 @@ public class UserHistoryDao {
     public void log(final UserHistory userHistory) {
         final var sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
         jdbcTemplate.update(sql,
+                userHistory.getUserId(),
+                userHistory.getAccount(),
+                userHistory.getPassword(),
+                userHistory.getEmail(),
+                userHistory.getCreatedAt(),
+                userHistory.getCreateBy()
+        );
+    }
+
+    /*
+    Connection 공유 버전 overloading
+     */
+    public void log(final Connection connection, final UserHistory userHistory) {
+        final var sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
+        jdbcTemplate.update(
+                connection, sql,
                 userHistory.getUserId(),
                 userHistory.getAccount(),
                 userHistory.getPassword(),

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -6,6 +6,7 @@ import com.techcourse.domain.User;
 import com.techcourse.domain.UserHistory;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.function.Consumer;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,22 +34,46 @@ public class UserService {
     }
 
     public void changePassword(final long id, final String newPassword, final String createBy) {
-        try(Connection connection = dataSource.getConnection()) {
+        doInTransaction(connection -> {
+            final var user = findById(id);
+            user.changePassword(newPassword);
+            userDao.update(connection, user);
+            userHistoryDao.log(connection, new UserHistory(user, createBy));
+        });
+    }
+
+    private void doInTransaction(Consumer<Connection> consumer){
+        Connection connection = null;
+        try {
+            connection = dataSource.getConnection();
             connection.setAutoCommit(false);
-            try {
-                final var user = findById(id);
-                user.changePassword(newPassword);
-                userDao.update(connection, user);
-                userHistoryDao.log(connection, new UserHistory(user, createBy));
-                connection.commit();
-            } catch (SQLException e){
-                log.error("Rollback 발생");
-                connection.rollback();
-                throw e;
-            }
-        } catch (SQLException e) {
+            consumer.accept(connection);
+            connection.commit();
+        } catch (Exception e) {
             log.error("비밀번호 변경 중 예외 발생");
-            throw new RuntimeException(e);
+            handleTransactionException(e, connection);
+        } finally {
+            closeConnection(connection);
+        }
+    }
+
+    private void handleTransactionException(Exception e, Connection connection) {
+        if(connection != null) {
+            try { // 커넥션이 존재할 경우 롤백 시도
+                connection.rollback();
+                log.info("Rollback 완료");
+            } catch (SQLException ex) { // 롤백 도중 예외 발생
+                log.error("Rollback 실패", ex);
+            }
+        }
+        throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException(e);
+    }
+
+    private void closeConnection(Connection connection) {
+        if(connection != null){ // 커넥션이 존재할 경우 close
+            try {
+                connection.close();
+            } catch (SQLException ignored) {}
         }
     }
 }

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -4,13 +4,22 @@ import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.domain.UserHistory;
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class UserService {
 
+    private static final Logger log = LoggerFactory.getLogger(UserService.class);
+
+    private final DataSource dataSource;
     private final UserDao userDao;
     private final UserHistoryDao userHistoryDao;
 
-    public UserService(final UserDao userDao, final UserHistoryDao userHistoryDao) {
+    public UserService(final DataSource dataSource, final UserDao userDao, final UserHistoryDao userHistoryDao) {
+        this.dataSource = dataSource;
         this.userDao = userDao;
         this.userHistoryDao = userHistoryDao;
     }
@@ -24,9 +33,22 @@ public class UserService {
     }
 
     public void changePassword(final long id, final String newPassword, final String createBy) {
-        final var user = findById(id);
-        user.changePassword(newPassword);
-        userDao.update(user);
-        userHistoryDao.log(new UserHistory(user, createBy));
+        try(Connection connection = dataSource.getConnection()) {
+            connection.setAutoCommit(false);
+            try {
+                final var user = findById(id);
+                user.changePassword(newPassword);
+                userDao.update(connection, user);
+                userHistoryDao.log(connection, new UserHistory(user, createBy));
+                connection.commit();
+            } catch (SQLException e){
+                log.error("Rollback 발생");
+                connection.rollback();
+                throw e;
+            }
+        } catch (SQLException e) {
+            log.error("비밀번호 변경 중 예외 발생");
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
+++ b/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
@@ -1,9 +1,10 @@
 package com.techcourse.service;
 
-import com.techcourse.dao.UserHistoryDao;
-import com.techcourse.domain.UserHistory;
 import com.interface21.dao.DataAccessException;
 import com.interface21.jdbc.core.JdbcTemplate;
+import com.techcourse.dao.UserHistoryDao;
+import com.techcourse.domain.UserHistory;
+import java.sql.Connection;
 
 public class MockUserHistoryDao extends UserHistoryDao {
 
@@ -12,7 +13,7 @@ public class MockUserHistoryDao extends UserHistoryDao {
     }
 
     @Override
-    public void log(final UserHistory userHistory) {
+    public void log(final Connection connection, final UserHistory userHistory) {
         throw new DataAccessException();
     }
 }

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -1,31 +1,32 @@
 package com.techcourse.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.interface21.dao.DataAccessException;
+import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
-import com.interface21.dao.DataAccessException;
-import com.interface21.jdbc.core.JdbcTemplate;
+import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-@Disabled
 class UserServiceTest {
 
+    private DataSource dataSource;
     private JdbcTemplate jdbcTemplate;
     private UserDao userDao;
 
     @BeforeEach
     void setUp() {
-        this.jdbcTemplate = new JdbcTemplate(DataSourceConfig.getInstance());
+        this.dataSource = DataSourceConfig.getInstance();
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
         this.userDao = new UserDao(jdbcTemplate);
 
-        DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
+        DatabasePopulatorUtils.execute(dataSource);
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
         userDao.insert(user);
     }
@@ -33,7 +34,7 @@ class UserServiceTest {
     @Test
     void testChangePassword() {
         final var userHistoryDao = new UserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao);
+        final var userService = new UserService(dataSource, userDao, userHistoryDao);
 
         final var newPassword = "qqqqq";
         final var createBy = "gugu";
@@ -48,7 +49,7 @@ class UserServiceTest {
     void testTransactionRollback() {
         // 트랜잭션 롤백 테스트를 위해 mock으로 교체
         final var userHistoryDao = new MockUserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao);
+        final var userService = new UserService(dataSource, userDao, userHistoryDao);
 
         final var newPassword = "newPassword";
         final var createBy = "gugu";

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -25,7 +25,20 @@ public class JdbcTemplate {
     public void update(String sql, Object... params){
         try (Connection conn = dataSource.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)){
+            log.debug("query : {}", sql);
+            setParameters(pstmt, params);
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+            throw new DataAccessException(e.getMessage(), e);
+        }
+    }
 
+    /*
+    Connection 공유 버전 오버로딩
+     */
+    public void update(Connection connection, String sql, Object... params){
+        try (PreparedStatement pstmt = connection.prepareStatement(sql)){
             log.debug("query : {}", sql);
             setParameters(pstmt, params);
             pstmt.executeUpdate();


### PR DESCRIPTION
안녕하세요 짱구!

이번 스텝은 비밀번호를 변경하는 메서드에 트랜잭션을 적용하는 미션이었습니다.

step3는 시작할 때 고민이 가장 오래 걸렸던 것 같아요..!
단순하게 그냥 같은 Connection을 DAO 메서드들이 공유하면 된다고 생각했는데, 막상 구현하고 보니 비즈니스 로직과 transaction 관리 로직이 하나의 메서드 내에 공존하는 것이 너무 불편하더라구요!
그래서 이를 AOP처럼 트랜잭션 관리와 비즈니스 로직 파트를 나눌 수 없을까 고민하다가 Spring의 구조를 조금 참고하고자 찾아봤었는데요,
`TransactionSynchronizationManager`라는 객체가 transaction을 위한 커넥션 관리 역할을 하고 있는 것 같았습니다.

LMS에서 미션 제목만 잠깐 봤을 때 아마 이 과정이 step4에서 학습할 부분인 것 같아서 추가 학습을 멈추고, 좀 더럽지만(?) service 계층에서 transaction을 직접 제어하는 코드로 남겨두었습니다..!

지금은 `service` 메서드 내 `doInTransaction(Consumer<Connection> consumer)` 콜백 패턴으로 트랜잭션을 처리하고 있습니다.
아마 이 부분이 다음 스텝에선 없어질 것 같은데 지금은 최소한의 메서드 분리를 하기 위해 사용했다고 봐주시면 될 것 같습니다!

이번에도 편할 때 리뷰 해주시면 감사하겠습니다 :)