### PR TITLE
[2단계 - 리팩터링] 랜디(김정우) 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory;
 public class UserDao {
 
     private static final Logger log = LoggerFactory.getLogger(UserDao.class);
-    private static final RowMapper<User> USER_ROW_MAPPER = (resultSet, rowNum) -> new User(
+    private static final RowMapper<User> USER_ROW_MAPPER = (resultSet) -> new User(
             resultSet.getLong("id"),
             resultSet.getString("account"),
             resultSet.getString("password"),

--- a/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
+++ b/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
@@ -1,9 +1,9 @@
 package com.techcourse.service;
 
+import com.interface21.exception.DataAccessException;
+import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.UserHistory;
-import com.interface21.dao.DataAccessException;
-import com.interface21.jdbc.core.JdbcTemplate;
 
 public class MockUserHistoryDao extends UserHistoryDao {
 

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -3,7 +3,7 @@ package com.techcourse.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.interface21.dao.DataAccessException;
+import com.interface21.exception.DataAccessException;
 import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.dao.UserDao;

--- a/jdbc/src/main/java/com/interface21/exception/CannotGetJdbcConnectionException.java
+++ b/jdbc/src/main/java/com/interface21/exception/CannotGetJdbcConnectionException.java
@@ -1,8 +1,8 @@
-package com.interface21.jdbc;
+package com.interface21.exception;
 
 import java.sql.SQLException;
 
-public class CannotGetJdbcConnectionException extends RuntimeException {
+public class CannotGetJdbcConnectionException extends DataAccessException {
 
     public CannotGetJdbcConnectionException(String msg) {
         super(msg);

--- a/jdbc/src/main/java/com/interface21/exception/DataAccessException.java
+++ b/jdbc/src/main/java/com/interface21/exception/DataAccessException.java
@@ -1,4 +1,4 @@
-package com.interface21.dao;
+package com.interface21.exception;
 
 public class DataAccessException extends RuntimeException {
 

--- a/jdbc/src/main/java/com/interface21/exception/ResultBindingException.java
+++ b/jdbc/src/main/java/com/interface21/exception/ResultBindingException.java
@@ -1,0 +1,18 @@
+package com.interface21.exception;
+
+import java.sql.SQLException;
+
+public class ResultBindingException extends DataAccessException {
+
+    public ResultBindingException(String msg) {
+        super(msg);
+    }
+
+    public ResultBindingException(String msg, SQLException ex) {
+        super(msg, ex);
+    }
+
+    public ResultBindingException(String msg, IllegalStateException ex) {
+        super(msg, ex);
+    }
+}

--- a/jdbc/src/main/java/com/interface21/exception/StatementExecuteQueryException.java
+++ b/jdbc/src/main/java/com/interface21/exception/StatementExecuteQueryException.java
@@ -1,0 +1,19 @@
+package com.interface21.exception;
+
+import java.sql.SQLException;
+
+public class StatementExecuteQueryException extends DataAccessException {
+
+    public StatementExecuteQueryException(String msg) {
+        super(msg);
+    }
+
+    public StatementExecuteQueryException(String msg, SQLException ex) {
+        super(msg, ex);
+    }
+
+    public StatementExecuteQueryException(String msg, IllegalStateException ex) {
+        super(msg, ex);
+    }
+}
+

--- a/jdbc/src/main/java/com/interface21/exception/StatementExecuteUpdateException.java
+++ b/jdbc/src/main/java/com/interface21/exception/StatementExecuteUpdateException.java
@@ -1,0 +1,18 @@
+package com.interface21.exception;
+
+import java.sql.SQLException;
+
+public class StatementExecuteUpdateException extends DataAccessException {
+
+    public StatementExecuteUpdateException(String msg) {
+        super(msg);
+    }
+
+    public StatementExecuteUpdateException(String msg, SQLException ex) {
+        super(msg, ex);
+    }
+
+    public StatementExecuteUpdateException(String msg, IllegalStateException ex) {
+        super(msg, ex);
+    }
+}

--- a/jdbc/src/main/java/com/interface21/exception/StatementParameterBindingException.java
+++ b/jdbc/src/main/java/com/interface21/exception/StatementParameterBindingException.java
@@ -1,0 +1,19 @@
+package com.interface21.exception;
+
+import java.sql.SQLException;
+
+public class StatementParameterBindingException extends DataAccessException {
+
+    public StatementParameterBindingException(String msg) {
+        super(msg);
+    }
+
+    public StatementParameterBindingException(String msg, SQLException ex) {
+        super(msg, ex);
+    }
+
+    public StatementParameterBindingException(String msg, IllegalStateException ex) {
+        super(msg, ex);
+    }
+}
+

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -107,7 +107,7 @@ public class JdbcTemplate {
             List<T> results = new ArrayList<>();
             int rowNum = 0;
             while (resultSet.next()) {
-                T result = rowMapper.mapRowToObject(resultSet, rowNum++);
+                T result = rowMapper.mapRowToObject(resultSet);
                 results.add(result);
             }
             return results;

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -113,6 +113,7 @@ public class JdbcTemplate {
                 T result = rowMapper.mapRowToObject(resultSet);
                 results.add(result);
             }
+            resultSet.close();
             return results;
         } catch (SQLException e) {
             log.error("조회 결과 바인딩 실패: {}", e.getMessage(), e);

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -43,8 +43,7 @@ public class JdbcTemplate {
                 PreparedStatement pstmt = conn.prepareStatement(sql)) {
             log.debug("query : {}", sql);
             bindPreparedStatement(pstmt, parameters);
-            ResultSet resultSet = executeQuery(pstmt);
-            List<T> result = bindQueryResults(resultSet, rowMapper);
+            List<T> result = executeQuery(pstmt, rowMapper);
             validateResultCountIsOne(result.size());
             return result.getFirst();
         } catch (SQLException e) {
@@ -58,8 +57,7 @@ public class JdbcTemplate {
                 PreparedStatement pstmt = conn.prepareStatement(sql)) {
             log.debug("query : {}", sql);
             bindPreparedStatement(pstmt, parameters);
-            ResultSet resultSet = executeQuery(pstmt);
-            return bindQueryResults(resultSet, rowMapper);
+            return executeQuery(pstmt, rowMapper);
         } catch (SQLException e) {
             log.error("SQL 예외 발생: {}", e.getMessage(), e);
             throw new DataAccessException("SQL 예외 발생", e);
@@ -97,9 +95,9 @@ public class JdbcTemplate {
         }
     }
 
-    private ResultSet executeQuery(PreparedStatement pstmt) {
-        try {
-            return pstmt.executeQuery();
+    private <T> List<T> executeQuery(PreparedStatement pstmt, RowMapper<T> rowMapper) {
+        try (ResultSet resultSet = pstmt.executeQuery()) {
+            return bindQueryResults(resultSet, rowMapper);
         } catch (SQLException e) {
             log.error("데이터 조회 실패: {}", e.getMessage(), e);
             throw new StatementExecuteQueryException("데이터 조회 실패", e);
@@ -113,7 +111,6 @@ public class JdbcTemplate {
                 T result = rowMapper.mapRowToObject(resultSet);
                 results.add(result);
             }
-            resultSet.close();
             return results;
         } catch (SQLException e) {
             log.error("조회 결과 바인딩 실패: {}", e.getMessage(), e);

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -1,7 +1,11 @@
 package com.interface21.jdbc.core;
 
-import com.interface21.dao.DataAccessException;
-import com.interface21.jdbc.CannotGetJdbcConnectionException;
+import com.interface21.exception.CannotGetJdbcConnectionException;
+import com.interface21.exception.DataAccessException;
+import com.interface21.exception.ResultBindingException;
+import com.interface21.exception.StatementExecuteQueryException;
+import com.interface21.exception.StatementExecuteUpdateException;
+import com.interface21.exception.StatementParameterBindingException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -80,7 +84,7 @@ public class JdbcTemplate {
             return pstmt;
         } catch (SQLException e) {
             log.error("쿼리의 파라미터 바인딩 실패: {}", e.getMessage(), e);
-            throw new DataAccessException("쿼리의 파라미터 바인딩 실패", e);
+            throw new StatementParameterBindingException("쿼리의 파라미터 바인딩 실패", e);
         }
     }
 
@@ -89,7 +93,7 @@ public class JdbcTemplate {
             pstmt.executeUpdate();
         } catch (SQLException e) {
             log.error("데이터 추가/수정 실패: {}", e.getMessage(), e);
-            throw new DataAccessException("데이터 추가/수정 실패", e);
+            throw new StatementExecuteUpdateException("데이터 추가/수정 실패", e);
         }
     }
 
@@ -98,14 +102,13 @@ public class JdbcTemplate {
             return pstmt.executeQuery();
         } catch (SQLException e) {
             log.error("데이터 조회 실패: {}", e.getMessage(), e);
-            throw new DataAccessException("데이터 조회 실패", e);
+            throw new StatementExecuteQueryException("데이터 조회 실패", e);
         }
     }
 
     private <T> List<T> bindQueryResults(ResultSet resultSet, RowMapper<T> rowMapper) {
         try {
             List<T> results = new ArrayList<>();
-            int rowNum = 0;
             while (resultSet.next()) {
                 T result = rowMapper.mapRowToObject(resultSet);
                 results.add(result);
@@ -113,14 +116,14 @@ public class JdbcTemplate {
             return results;
         } catch (SQLException e) {
             log.error("조회 결과 바인딩 실패: {}", e.getMessage(), e);
-            throw new DataAccessException("조회 결과 바인딩 실패", e);
+            throw new ResultBindingException("조회 결과 바인딩 실패", e);
         }
     }
 
     private void validateResultCountIsOne(int actualCount) {
         if (actualCount != 1) {
             log.error("조회 결과 바인딩 실패: 조회 결과가 존재하지 않거나 여러개가 존재");
-            throw new DataAccessException("조회 결과 바인딩 실패 : 조회 결과가 존재하지 않거나 여러개가 존재");
+            throw new ResultBindingException("조회 결과 바인딩 실패 : 조회 결과가 존재하지 않거나 여러개가 존재");
         }
     }
 }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/RowMapper.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/RowMapper.java
@@ -6,5 +6,5 @@ import java.sql.SQLException;
 @FunctionalInterface
 public interface RowMapper<T> {
 
-    T mapRowToObject(ResultSet resultSet, Integer rowNumber) throws SQLException;
+    T mapRowToObject(ResultSet resultSet) throws SQLException;
 }

--- a/jdbc/src/main/java/com/interface21/jdbc/datasource/DataSourceUtils.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/datasource/DataSourceUtils.java
@@ -1,16 +1,16 @@
 package com.interface21.jdbc.datasource;
 
-import com.interface21.jdbc.CannotGetJdbcConnectionException;
+import com.interface21.exception.CannotGetJdbcConnectionException;
 import com.interface21.transaction.support.TransactionSynchronizationManager;
-
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
+import javax.sql.DataSource;
 
 // 4단계 미션에서 사용할 것
 public abstract class DataSourceUtils {
 
-    private DataSourceUtils() {}
+    private DataSourceUtils() {
+    }
 
     public static Connection getConnection(DataSource dataSource) throws CannotGetJdbcConnectionException {
         Connection connection = TransactionSynchronizationManager.getResource(dataSource);

--- a/study/src/test/java/transaction/stage1/Stage1Test.java
+++ b/study/src/test/java/transaction/stage1/Stage1Test.java
@@ -1,7 +1,13 @@
 package transaction.stage1;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.TimeUnit;
+import javax.sql.DataSource;
 import org.h2.jdbcx.JdbcDataSource;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -13,31 +19,16 @@ import org.testcontainers.utility.DockerImageName;
 import transaction.DatabasePopulatorUtils;
 import transaction.RunnableWrapper;
 
-import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.concurrent.TimeUnit;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 /**
- * 격리 레벨(Isolation Level)에 따라 여러 사용자가 동시에 db에 접근했을 때 어떤 문제가 발생하는지 확인해보자.
- * ❗phantom reads는 docker를 실행한 상태에서 테스트를 실행한다.
+ * 격리 레벨(Isolation Level)에 따라 여러 사용자가 동시에 db에 접근했을 때 어떤 문제가 발생하는지 확인해보자. ❗phantom reads는 docker를 실행한 상태에서 테스트를 실행한다.
  * ❗phantom reads는 MySQL로 확인한다. H2 데이터베이스에서는 발생하지 않는다.
- *
- * 참고 링크
- * https://en.wikipedia.org/wiki/Isolation_(database_systems)
- *
- * 각 테스트에서 어떤 현상이 발생하는지 직접 경험해보고 아래 표를 채워보자.
- * + : 발생
- * - : 발생하지 않음
- *   Read phenomena | Dirty reads | Non-repeatable reads | Phantom reads
- * Isolation level  |             |                      |
- * -----------------|-------------|----------------------|--------------
- * Read Uncommitted |             |                      |
- * Read Committed   |             |                      |
- * Repeatable Read  |             |                      |
- * Serializable     |             |                      |
+ * <p>
+ * 참고 링크 https://en.wikipedia.org/wiki/Isolation_(database_systems)
+ * <p>
+ * 각 테스트에서 어떤 현상이 발생하는지 직접 경험해보고 아래 표를 채워보자. + : 발생 - : 발생하지 않음 Read phenomena | Dirty reads | Non-repeatable reads |
+ * Phantom reads Isolation level  |             |                      |
+ * -----------------|-------------|----------------------|-------------- Read Uncommitted |             | | Read
+ * Committed   |             |                      | Repeatable Read  |             | | Serializable     | | |
  */
 class Stage1Test {
 
@@ -52,16 +43,8 @@ class Stage1Test {
     }
 
     /**
-     * 격리 수준에 따라 어떤 현상이 발생하는지 테스트를 돌려 직접 눈으로 확인하고 표를 채워보자.
-     * + : 발생
-     * - : 발생하지 않음
-     *   Read phenomena | Dirty reads
-     * Isolation level  |
-     * -----------------|-------------
-     * Read Uncommitted |
-     * Read Committed   |
-     * Repeatable Read  |
-     * Serializable     |
+     * 격리 수준에 따라 어떤 현상이 발생하는지 테스트를 돌려 직접 눈으로 확인하고 표를 채워보자. + : 발생 - : 발생하지 않음 Read phenomena | Dirty reads Isolation
+     * level  | -----------------|------------- Read Uncommitted | Read Committed   | Repeatable Read  | Serializable |
      */
     @Test
     void dirtyReading() throws SQLException {
@@ -81,7 +64,7 @@ class Stage1Test {
             final var subConnection = dataSource.getConnection();
 
             // 적절한 격리 레벨을 찾는다.
-            final int isolationLevel = Connection.TRANSACTION_NONE;
+            final int isolationLevel = Connection.TRANSACTION_SERIALIZABLE;
 
             // 트랜잭션 격리 레벨을 설정한다.
             subConnection.setTransactionIsolation(isolationLevel);
@@ -105,16 +88,9 @@ class Stage1Test {
     }
 
     /**
-     * 격리 수준에 따라 어떤 현상이 발생하는지 테스트를 돌려 직접 눈으로 확인하고 표를 채워보자.
-     * + : 발생
-     * - : 발생하지 않음
-     *   Read phenomena | Non-repeatable reads
-     * Isolation level  |
-     * -----------------|---------------------
-     * Read Uncommitted |
-     * Read Committed   |
-     * Repeatable Read  |
-     * Serializable     |
+     * 격리 수준에 따라 어떤 현상이 발생하는지 테스트를 돌려 직접 눈으로 확인하고 표를 채워보자. + : 발생 - : 발생하지 않음 Read phenomena | Non-repeatable reads
+     * Isolation level  | -----------------|--------------------- Read Uncommitted | Read Committed   | Repeatable Read
+     * | Serializable     |
      */
     @Test
     void noneRepeatable() throws SQLException {
@@ -130,7 +106,7 @@ class Stage1Test {
         connection.setAutoCommit(false);
 
         // 적절한 격리 레벨을 찾는다.
-        final int isolationLevel = Connection.TRANSACTION_NONE;
+        final int isolationLevel = Connection.TRANSACTION_SERIALIZABLE;
 
         // 트랜잭션 격리 레벨을 설정한다.
         connection.setTransactionIsolation(isolationLevel);
@@ -166,17 +142,9 @@ class Stage1Test {
     }
 
     /**
-     * phantom read는 h2에서 발생하지 않는다. mysql로 확인해보자.
-     * 격리 수준에 따라 어떤 현상이 발생하는지 테스트를 돌려 직접 눈으로 확인하고 표를 채워보자.
-     * + : 발생
-     * - : 발생하지 않음
-     *   Read phenomena | Phantom reads
-     * Isolation level  |
-     * -----------------|--------------
-     * Read Uncommitted |
-     * Read Committed   |
-     * Repeatable Read  |
-     * Serializable     |
+     * phantom read는 h2에서 발생하지 않는다. mysql로 확인해보자. 격리 수준에 따라 어떤 현상이 발생하는지 테스트를 돌려 직접 눈으로 확인하고 표를 채워보자. + : 발생 - : 발생하지 않음
+     * Read phenomena | Phantom reads Isolation level  | -----------------|-------------- Read Uncommitted | Read
+     * Committed   | Repeatable Read  | Serializable     |
      */
     @Test
     void phantomReading() throws SQLException {
@@ -197,7 +165,7 @@ class Stage1Test {
         connection.setAutoCommit(false);
 
         // 적절한 격리 레벨을 찾는다.
-        final int isolationLevel = Connection.TRANSACTION_NONE;
+        final int isolationLevel = Connection.TRANSACTION_SERIALIZABLE;
 
         // 트랜잭션 격리 레벨을 설정한다.
         connection.setTransactionIsolation(isolationLevel);
@@ -239,7 +207,7 @@ class Stage1Test {
 
     private static DataSource createMySQLDataSource(final JdbcDatabaseContainer<?> container) {
         final var config = new HikariConfig();
-        config.setJdbcUrl(container.getJdbcUrl());
+        config.setJdbcUrl(container.getJdbcUrl() + "?allowMultiQueries=true");
         config.setUsername(container.getUsername());
         config.setPassword(container.getPassword());
         config.setDriverClassName(container.getDriverClassName());


### PR DESCRIPTION
안녕하세요! 피글렛!
미션을 진행하며 고려한 점은 아래에 정리했습니다!
이번 2단계도 리뷰 잘부탁드려요!

---

**TODO**

- [x]  RowMapper의 mapRow()에서 불필요한 rowNum 매개변수 제거
- [x]  커스텀 Unchecked  Exception을 추가
- [x]  ResultSet 닫기

**LMS 진행순서처럼 JdbcTemplate를 추상클래스로 만들어야 할까?**

- 미션 요구사항 분석 (LMS의 “2단계-리펙토링”에 명시된 리펙토링 내용을 분석해보았습니다!)
    - JdbcTemplate를 추상 클래스로 변경
    - JdbcTemplate의 주요 로직에서 가변 로직 부분을 추상 메서드로 분리 (템플릿 메서드 패턴)
    - UserDao에서는 JdbcTemplate을 상속받는 익명 클래스 객체를 생성해서 사용
- “JdbcTemplate를 추상 클래스”로 만들 경우와 “기존 방식”의 UserDao 코드 비교
    - JdbcTemplate를 추상클래스로 만들 경우 UserDao
        - JdbcTemplate을 상속받는 익명 클래스를 정의
        - 정의된 익명 클래스를 객체로 생성해서 활용
    - 기존 방식의 경우 UserDao
        - JdbcTemplate를 생성자로 생성 또는 의존성 주입받음
        - JdbcTemplate이 제공하는 public 메서드를 활용
- JdbcTemplate를 추상클래스로 만드는 것은 다음과 같은 이유로 불필요하다고 판단했습니다!
    - 기존 방식이 사용자 입장에서 JdbcTemplate을 사용하기 쉽습니다!
    - 기본의 방식의 경우 DI가 가능하기에 DI의 이점을 누릴 수 있습니다!

**커스텀 예외는 어떻게 구현해야할까?**

- 커스텀 예외 조건
    - Unchecked  Exception 예외
    - 최상위 예외인 DataAccessException의 하위 예외
- 커스텀 예외 구현 방식
    - DataAccessException는 RuntimeException을 상속받는 Unchecked  Exception입니다!
    - 그렇기에 DataAccessException를 상속받는 하위 커스텀 예외를 만들어 사용하도록 구현했습니다!
- 커스텀 예외의 패키지 위치
    - 커스텀 예외들은 DB 작업을 수행하여 발생하는 JdbcTemplate계층의 예외입니다!
    - 그렇기에 JdbcTemplate 모듈 내에 JdbcTemplate계층 예외를 관리하는 com.interface21.exception 패키지를 만들고, 해당 패키지에 DataAccessException을 비롯한 각종 커스텀 예외들을 배치했습니다!