### PR TITLE
[4단계 - Transaction synchronization 적용하기] 모루 (최동준) 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/service/AppUserService.java
+++ b/app/src/main/java/com/techcourse/service/AppUserService.java
@@ -1,0 +1,37 @@
+package com.techcourse.service;
+
+import com.techcourse.dao.UserDao;
+import com.techcourse.dao.UserHistoryDao;
+import com.techcourse.domain.User;
+import com.techcourse.domain.UserHistory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AppUserService implements UserService{
+
+    private final UserDao userDao;
+    private final UserHistoryDao userHistoryDao;
+
+    public AppUserService(final UserDao userDao, final UserHistoryDao userHistoryDao) {
+        this.userDao = userDao;
+        this.userHistoryDao = userHistoryDao;
+    }
+
+    @Override
+    public User findById(final long id) {
+        return userDao.findById(id);
+    }
+
+    @Override
+    public void insert(final User user) {
+        userDao.insert(user);
+    }
+
+    @Override
+    public void changePassword(final long id, final String newPassword, final String createBy) {
+        final var user = findById(id);
+        user.changePassword(newPassword);
+        userDao.update(user);
+        userHistoryDao.log(new UserHistory(user, createBy));
+    }
+}

--- a/app/src/main/java/com/techcourse/service/TxUserService.java
+++ b/app/src/main/java/com/techcourse/service/TxUserService.java
@@ -1,24 +1,16 @@
 package com.techcourse.service;
 
-import com.interface21.dao.DataAccessException;
-import com.interface21.jdbc.core.TransactionManager;
-import com.techcourse.dao.UserDao;
-import com.techcourse.dao.UserHistoryDao;
+import com.interface21.jdbc.core.TransactionTemplate;
 import com.techcourse.domain.User;
-import com.techcourse.domain.UserHistory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TxUserService implements UserService{
 
-    private static final Logger log = LoggerFactory.getLogger(TxUserService.class);
-
     private final UserService userService;
-    private final TransactionManager transactionManager;
+    private final TransactionTemplate transactionTemplate;
 
-    public TxUserService(UserService userService, TransactionManager transactionManager) {
+    public TxUserService(UserService userService, TransactionTemplate transactionTemplate) {
         this.userService = userService;
-        this.transactionManager = transactionManager;
+        this.transactionTemplate = transactionTemplate;
     }
 
     @Override
@@ -28,25 +20,11 @@ public class TxUserService implements UserService{
 
     @Override
     public void insert(final User user) {
-        transactionManager.start();
-        try {
-            userService.insert(user);
-            transactionManager.commit();
-        } catch (Exception e) {
-            transactionManager.rollback();
-            throw new DataAccessException("메서드 실행 중 예외가 발생하여 롤백합니다.", e);
-        }
+        transactionTemplate.execute(() -> userService.insert(user));
     }
 
     @Override
     public void changePassword(final long id, final String newPassword, final String createBy) {
-        transactionManager.start();
-        try {
-            userService.changePassword(id, newPassword, createBy);
-            transactionManager.commit();
-        } catch (Exception e) {
-            transactionManager.rollback();
-            throw new DataAccessException("메서드 실행 중 예외가 발생하여 롤백합니다.", e);
-        }
+        transactionTemplate.execute(() -> userService.changePassword(id, newPassword, createBy));
     }
 }

--- a/app/src/main/java/com/techcourse/service/TxUserService.java
+++ b/app/src/main/java/com/techcourse/service/TxUserService.java
@@ -1,0 +1,52 @@
+package com.techcourse.service;
+
+import com.interface21.dao.DataAccessException;
+import com.interface21.jdbc.core.TransactionManager;
+import com.techcourse.dao.UserDao;
+import com.techcourse.dao.UserHistoryDao;
+import com.techcourse.domain.User;
+import com.techcourse.domain.UserHistory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TxUserService implements UserService{
+
+    private static final Logger log = LoggerFactory.getLogger(TxUserService.class);
+
+    private final UserService userService;
+    private final TransactionManager transactionManager;
+
+    public TxUserService(UserService userService, TransactionManager transactionManager) {
+        this.userService = userService;
+        this.transactionManager = transactionManager;
+    }
+
+    @Override
+    public User findById(final long id) {
+        return userService.findById(id);
+    }
+
+    @Override
+    public void insert(final User user) {
+        transactionManager.start();
+        try {
+            userService.insert(user);
+            transactionManager.commit();
+        } catch (Exception e) {
+            transactionManager.rollback();
+            throw new DataAccessException("메서드 실행 중 예외가 발생하여 롤백합니다.", e);
+        }
+    }
+
+    @Override
+    public void changePassword(final long id, final String newPassword, final String createBy) {
+        transactionManager.start();
+        try {
+            userService.changePassword(id, newPassword, createBy);
+            transactionManager.commit();
+        } catch (Exception e) {
+            transactionManager.rollback();
+            throw new DataAccessException("메서드 실행 중 예외가 발생하여 롤백합니다.", e);
+        }
+    }
+}

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -12,12 +12,15 @@ import org.slf4j.LoggerFactory;
 public class UserService {
 
     private static final Logger log = LoggerFactory.getLogger(UserService.class);
+
     private final UserDao userDao;
     private final UserHistoryDao userHistoryDao;
+    private final TransactionManager transactionManager;
 
-    public UserService(final UserDao userDao, final UserHistoryDao userHistoryDao) {
+    public UserService(final UserDao userDao, final UserHistoryDao userHistoryDao, final TransactionManager transactionManager) {
         this.userDao = userDao;
         this.userHistoryDao = userHistoryDao;
+        this.transactionManager = transactionManager;
     }
 
     public User findById(final long id) {
@@ -25,26 +28,26 @@ public class UserService {
     }
 
     public void insert(final User user) {
-        TransactionManager.start();
+        transactionManager.start();
         try {
             userDao.insert(user);
-            TransactionManager.commit();
+            transactionManager.commit();
         } catch (Exception e) {
-            TransactionManager.rollback();
+            transactionManager.rollback();
             throw new DataAccessException("메서드 실행 중 예외가 발생하여 롤백합니다.", e);
         }
     }
 
     public void changePassword(final long id, final String newPassword, final String createBy) {
-        TransactionManager.start();
+        transactionManager.start();
         try {
             final var user = findById(id);
             user.changePassword(newPassword);
             userDao.update(user);
             userHistoryDao.log(new UserHistory(user, createBy));
-            TransactionManager.commit();
+            transactionManager.commit();
         } catch (Exception e) {
-            TransactionManager.rollback();
+            transactionManager.rollback();
             throw new DataAccessException("메서드 실행 중 예외가 발생하여 롤백합니다.", e);
         }
     }

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -1,54 +1,11 @@
 package com.techcourse.service;
 
-import com.interface21.dao.DataAccessException;
-import com.interface21.jdbc.core.TransactionManager;
-import com.techcourse.dao.UserDao;
-import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
-import com.techcourse.domain.UserHistory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class UserService {
+public interface UserService {
 
-    private static final Logger log = LoggerFactory.getLogger(UserService.class);
-
-    private final UserDao userDao;
-    private final UserHistoryDao userHistoryDao;
-    private final TransactionManager transactionManager;
-
-    public UserService(final UserDao userDao, final UserHistoryDao userHistoryDao, final TransactionManager transactionManager) {
-        this.userDao = userDao;
-        this.userHistoryDao = userHistoryDao;
-        this.transactionManager = transactionManager;
-    }
-
-    public User findById(final long id) {
-        return userDao.findById(id);
-    }
-
-    public void insert(final User user) {
-        transactionManager.start();
-        try {
-            userDao.insert(user);
-            transactionManager.commit();
-        } catch (Exception e) {
-            transactionManager.rollback();
-            throw new DataAccessException("메서드 실행 중 예외가 발생하여 롤백합니다.", e);
-        }
-    }
-
-    public void changePassword(final long id, final String newPassword, final String createBy) {
-        transactionManager.start();
-        try {
-            final var user = findById(id);
-            user.changePassword(newPassword);
-            userDao.update(user);
-            userHistoryDao.log(new UserHistory(user, createBy));
-            transactionManager.commit();
-        } catch (Exception e) {
-            transactionManager.rollback();
-            throw new DataAccessException("메서드 실행 중 예외가 발생하여 롤백합니다.", e);
-        }
-    }
+    User findById(final long id);
+    void insert(final User user);
+    void changePassword(final long id, final String newPassword, final String createdBy);
 }
+

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -5,11 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.interface21.dao.DataAccessException;
 import com.interface21.jdbc.core.TransactionManager;
+import com.interface21.jdbc.core.TransactionTemplate;
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
-import com.techcourse.domain.UserHistory;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +19,7 @@ class UserServiceTest {
 
     private UserDao userDao;
     private DataSource dataSource;
+    private TransactionTemplate transactionTemplate;
     private TransactionManager transactionManager;
 
     @BeforeEach
@@ -26,6 +27,7 @@ class UserServiceTest {
         this.dataSource = DataSourceConfig.getInstance();
         this.userDao = new UserDao(dataSource);
         this.transactionManager = new TransactionManager(dataSource);
+        this.transactionTemplate = new TransactionTemplate(transactionManager);
         DatabasePopulatorUtils.execute(dataSource);
         userDao.deleteAll();
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
@@ -51,7 +53,7 @@ class UserServiceTest {
     void testTransactionRollback() {
         final var userHistoryDao = new MockUserHistoryDao(dataSource);
         final var appUserService = new AppUserService(userDao, userHistoryDao);
-        final var userService = new TxUserService(appUserService, transactionManager);
+        final var userService = new TxUserService(appUserService, transactionTemplate);
 
         final var newPassword = "newPassword";
         final var createdBy = "gugu";

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -35,7 +35,7 @@ class UserServiceTest {
     @Test
     void testChangePassword() {
         final var userHistoryDao = new UserHistoryDao(dataSource);
-        final var userService = new UserService(userDao, userHistoryDao, transactionManager);
+        final var userService = new AppUserService(userDao, userHistoryDao);
 
         final var newPassword = "qqqqq";
         final var createBy = "gugu";
@@ -49,24 +49,20 @@ class UserServiceTest {
 
     @Test
     void testTransactionRollback() {
-        // 트랜잭션 롤백 테스트를 위해 mock으로 교체
-        final var userHistoryDao = new UserHistoryDao(dataSource) {
-            @Override
-            public void log(final UserHistory userHistory) {
-                throw new DataAccessException("롤백 테스트를 위한 예외");
-            }
-        };
-        final var userService = new UserService(userDao, userHistoryDao, transactionManager);
+        final var userHistoryDao = new MockUserHistoryDao(dataSource);
+        final var appUserService = new AppUserService(userDao, userHistoryDao);
+        final var userService = new TxUserService(appUserService, transactionManager);
 
         final var newPassword = "newPassword";
-        final var createBy = "gugu";
-        final var user = userDao.findByAccount(createBy);
-        // 트랜잭션이 정상 동작하는지 확인하기 위해 의도적으로 MockUserHistoryDao에서 예외를 발생시킨다.
+        final var createdBy = "gugu";
+
+        final var user = userDao.findByAccount(createdBy);
+        final var originalPassword = user.getPassword();
+
         assertThrows(DataAccessException.class,
-                () -> userService.changePassword(user.getId(), newPassword, createBy));
+                () -> userService.changePassword(user.getId(), newPassword, createdBy));
 
-        final var actual = userDao.findById(user.getId());
-
-        assertThat(actual.getPassword()).isNotEqualTo(newPassword);
+        final var actual = userService.findById(user.getId());
+        assertThat(actual.getPassword()).isEqualTo(originalPassword);
     }
 }

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -19,12 +19,13 @@ class UserServiceTest {
 
     private UserDao userDao;
     private DataSource dataSource;
+    private TransactionManager transactionManager;
 
     @BeforeEach
     void setUp() {
         this.dataSource = DataSourceConfig.getInstance();
         this.userDao = new UserDao(dataSource);
-        TransactionManager.initialize(dataSource);
+        this.transactionManager = new TransactionManager(dataSource);
         DatabasePopulatorUtils.execute(dataSource);
         userDao.deleteAll();
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
@@ -34,7 +35,7 @@ class UserServiceTest {
     @Test
     void testChangePassword() {
         final var userHistoryDao = new UserHistoryDao(dataSource);
-        final var userService = new UserService(userDao, userHistoryDao);
+        final var userService = new UserService(userDao, userHistoryDao, transactionManager);
 
         final var newPassword = "qqqqq";
         final var createBy = "gugu";
@@ -55,7 +56,7 @@ class UserServiceTest {
                 throw new DataAccessException("롤백 테스트를 위한 예외");
             }
         };
-        final var userService = new UserService(userDao, userHistoryDao);
+        final var userService = new UserService(userDao, userHistoryDao, transactionManager);
 
         final var newPassword = "newPassword";
         final var createBy = "gugu";

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcExecutor.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcExecutor.java
@@ -1,6 +1,7 @@
 package com.interface21.jdbc.core;
 
 import com.interface21.jdbc.core.exception.DataAccessException;
+import com.interface21.jdbc.datasource.DataSourceUtils;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -58,17 +59,7 @@ public class JdbcExecutor {
     }
 
     private Connection getConnection() {
-        try {
-            // ThreadLocal에 Connection이 있으면 그것을 사용 (트랜잭션 중)
-            Connection transactionConn = TransactionManager.getCurrentConnection();
-            if (transactionConn != null) {
-                return transactionConn;
-            }
-            // 없으면 새로 생성 (일반 사용)
-            return dataSource.getConnection();
-        } catch (SQLException e) {
-            throw new DataAccessException("Connection 획득 중 오류 발생", e);
-        }
+        return DataSourceUtils.getConnection(dataSource);
     }
 }
 

--- a/jdbc/src/main/java/com/interface21/jdbc/core/TransactionManager.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/TransactionManager.java
@@ -9,17 +9,17 @@ import org.slf4j.LoggerFactory;
 
 public class TransactionManager {
 
-    private static final ThreadLocal<Connection> connectionHolder = new ThreadLocal<>();
+    private final ThreadLocal<Connection> connectionHolder = new ThreadLocal<>();
 
     private static final Logger log = LoggerFactory.getLogger(TransactionManager.class);
 
-    private static DataSource dataSource;
-    
-    public static void initialize(DataSource dataSource) {
-        TransactionManager.dataSource = dataSource;
+    private final DataSource dataSource;
+
+    public TransactionManager(DataSource dataSource) {
+        this.dataSource = dataSource;
     }
 
-    public static void start() {
+    public void start() {
         if (connectionHolder.get() != null) {
             throw new IllegalStateException("이미 트랜잭션이 시작되었습니다.");
         }
@@ -33,11 +33,11 @@ public class TransactionManager {
         }
     }
 
-    public static Connection getCurrentConnection() {
+    public Connection getCurrentConnection() {
         return connectionHolder.get();
     }
 
-    public static void commit() {
+    public void commit() {
         try {
             Connection connection = getCurrentConnection();
             if (connection == null) {
@@ -52,7 +52,7 @@ public class TransactionManager {
         }
     }
 
-    public static void rollback() {
+    public void rollback() {
         try {
             Connection connection = getCurrentConnection();
             if (connection == null) {
@@ -67,7 +67,7 @@ public class TransactionManager {
         }
     }
 
-    public static void end() {
+    private void end() {
         Connection connection = connectionHolder.get();
         connectionHolder.remove();
         if (connection != null) {

--- a/jdbc/src/main/java/com/interface21/jdbc/core/TransactionManager.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/TransactionManager.java
@@ -75,7 +75,6 @@ public class TransactionManager {
                 connection.close();
             } catch (SQLException e) {
                 log.error("Connection 정리 중 오류 발생", e);
-                throw new DataAccessException("Connection 정리 실패", e);
             }
         }
     }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/TransactionManager.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/TransactionManager.java
@@ -1,6 +1,8 @@
 package com.interface21.jdbc.core;
 
 import com.interface21.dao.DataAccessException;
+import com.interface21.jdbc.datasource.DataSourceUtils;
+import com.interface21.transaction.support.TransactionSynchronizationManager;
 import java.sql.Connection;
 import java.sql.SQLException;
 import javax.sql.DataSource;
@@ -8,8 +10,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class TransactionManager {
-
-    private final ThreadLocal<Connection> connectionHolder = new ThreadLocal<>();
 
     private static final Logger log = LoggerFactory.getLogger(TransactionManager.class);
 
@@ -20,21 +20,17 @@ public class TransactionManager {
     }
 
     public void start() {
-        if (connectionHolder.get() != null) {
+        if (TransactionSynchronizationManager.getResource(dataSource) != null) {
             throw new IllegalStateException("이미 트랜잭션이 시작되었습니다.");
         }
         try {
             Connection connection = dataSource.getConnection();
             connection.setAutoCommit(false);
-            connectionHolder.set(connection);
+            TransactionSynchronizationManager.bindResource(dataSource, connection);
         } catch (SQLException e) {
             log.error("트랜잭션 시작 중 오류 발생", e);
             throw new DataAccessException("트랜잭션 시작 실패", e);
         }
-    }
-
-    public Connection getCurrentConnection() {
-        return connectionHolder.get();
     }
 
     public void commit() {
@@ -48,7 +44,7 @@ public class TransactionManager {
             log.error("트랜잭션 커밋 중 오류 발생", e);
             throw new DataAccessException("트랜잭션 커밋 실패", e);
         } finally {
-            end();
+            cleanup();
         }
     }
 
@@ -63,19 +59,23 @@ public class TransactionManager {
             log.error("트랜잭션 롤백 중 오류 발생", e);
             throw new DataAccessException("트랜잭션 롤백 실패", e);
         } finally {
-            end();
+            cleanup();
         }
     }
 
-    private void end() {
-        Connection connection = connectionHolder.get();
-        connectionHolder.remove();
+    private Connection getCurrentConnection() {
+        return DataSourceUtils.getConnection(dataSource);
+    }
+
+    private void cleanup() {
+        Connection connection = getCurrentConnection();
         if (connection != null) {
             try {
-                connection.close();
-            } catch (SQLException e) {
+                DataSourceUtils.releaseConnection(connection, dataSource);
+            } catch (Exception e) {
                 log.error("Connection 정리 중 오류 발생", e);
             }
         }
+        TransactionSynchronizationManager.unbindResource(dataSource);
     }
 }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/TransactionTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/TransactionTemplate.java
@@ -1,0 +1,38 @@
+package com.interface21.jdbc.core;
+
+import com.interface21.dao.DataAccessException;
+import java.util.function.Supplier;
+
+public class TransactionTemplate {
+
+    private final TransactionManager transactionManager;
+
+    public TransactionTemplate(TransactionManager transactionManager) {
+        this.transactionManager = transactionManager;
+    }
+
+    // 반환값이 없을 때 사용
+    public void execute(Runnable runnable) {
+        transactionManager.start();
+        try {
+            runnable.run();
+            transactionManager.commit();
+        } catch (Exception e) {
+            transactionManager.rollback();
+            throw new DataAccessException("메서드 실행 중 예외가 발생하여 롤백합니다.", e);
+        }
+    }
+
+    // 반환값이 있을 때 사용
+    public <T> T execute(Supplier<T> task) {
+        transactionManager.start();
+        try {
+            T result = task.get();
+            transactionManager.commit();
+            return result;
+        } catch (Exception e) {
+            transactionManager.rollback();
+            throw new DataAccessException("메서드 실행 중 예외가 발생하여 롤백합니다.", e);
+        }
+    }
+}

--- a/jdbc/src/main/java/com/interface21/jdbc/datasource/DataSourceUtils.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/datasource/DataSourceUtils.java
@@ -14,13 +14,14 @@ public abstract class DataSourceUtils {
 
     public static Connection getConnection(DataSource dataSource) throws CannotGetJdbcConnectionException {
         Connection connection = TransactionSynchronizationManager.getResource(dataSource);
+        //트랜잭션 중이면 재사용
         if (connection != null) {
             return connection;
         }
 
         try {
+            // 바인딩하지 않고 바로 반환 (트랜잭션 시작 시에만 바인딩)
             connection = dataSource.getConnection();
-            TransactionSynchronizationManager.bindResource(dataSource, connection);
             return connection;
         } catch (SQLException ex) {
             throw new CannotGetJdbcConnectionException("Failed to obtain JDBC Connection", ex);

--- a/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
+++ b/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
@@ -21,10 +21,6 @@ public abstract class TransactionSynchronizationManager {
 
     public static void bindResource(DataSource key, Connection value) {
         Map<DataSource, Connection> resourceMap = resources.get();
-        if (resourceMap == null) {
-            resourceMap = new HashMap<>();
-            resources.set(resourceMap);
-        }
         resourceMap.put(key, value);
     }
 

--- a/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
+++ b/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
@@ -2,22 +2,37 @@ package com.interface21.transaction.support;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
+import java.util.HashMap;
 import java.util.Map;
 
 public abstract class TransactionSynchronizationManager {
 
-    private static final ThreadLocal<Map<DataSource, Connection>> resources = new ThreadLocal<>();
+    private static final ThreadLocal<Map<DataSource, Connection>> resources = ThreadLocal.withInitial(HashMap::new);
 
     private TransactionSynchronizationManager() {}
 
     public static Connection getResource(DataSource key) {
-        return null;
+        Map<DataSource, Connection> resourceMap = resources.get();
+        if (resourceMap == null) {
+            return null;
+        }
+        return resourceMap.get(key);
     }
 
     public static void bindResource(DataSource key, Connection value) {
+        Map<DataSource, Connection> resourceMap = resources.get();
+        if (resourceMap == null) {
+            resourceMap = new HashMap<>();
+            resources.set(resourceMap);
+        }
+        resourceMap.put(key, value);
     }
 
     public static Connection unbindResource(DataSource key) {
-        return null;
+        Map<DataSource, Connection> resourceMap = resources.get();
+        if (resourceMap == null) {
+            return null;
+        }
+        return resourceMap.remove(key);
     }
 }

--- a/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
+++ b/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
@@ -13,9 +13,6 @@ public abstract class TransactionSynchronizationManager {
 
     public static Connection getResource(DataSource key) {
         Map<DataSource, Connection> resourceMap = resources.get();
-        if (resourceMap == null) {
-            return null;
-        }
         return resourceMap.get(key);
     }
 
@@ -26,9 +23,6 @@ public abstract class TransactionSynchronizationManager {
 
     public static Connection unbindResource(DataSource key) {
         Map<DataSource, Connection> resourceMap = resources.get();
-        if (resourceMap == null) {
-            return null;
-        }
         return resourceMap.remove(key);
     }
 }


### PR DESCRIPTION
안녕하세요 조로!! 연휴가 가기 전에 미션을 끝냈습니다! ㅎㅎ 
리뷰 완전 천천히 해주셔도 됩니다!

### 생긴 문제
`DataSourceUtils.getConnection()`이 트랜잭션 여부와 상관없이 항상 ThreadLocal에 Connection을 바인딩하여, `UserServiceTest`의 `setUp()`의 `userDao.insert()`같은 일반 DB 작업도 ThreadLocal에 Connection을 남겨두었습니다. 그래서, 실제 테스트 메서드를 실행하려 하면, 이미 커넥션이 존재하여 예외가 발생했습니다.

### 해결
이를 해결하려면, 일반 DB 작업과 사용자가 트랜잭션이 필요하다고 지정한 메서드의 Connection 획득을 확실하게 구분해야 했습니다.
원래는 `JdbcExecutor`에서 일반 DB 작업과 트랜잭션이 필요한 작업을 구분하여 커넥션을 가져왔는데, `JdbcExecutor`는 단순히 SQL을 실행하는 책임만 가지면 된다고 생각했습니다. 그래서, `DataSourceUtils`에서 그 커넥션 관리를 수행하도록 했습니다.
`DataSourceUtils`에서는 ThreadLocal에 Connection이 있으면 재사용하고, 없으면 새로 생성하되 바인딩하지 않도록 수정했습니다. `TransactionManager`에서는 start() 시에만 명시적으로 Connection을 ThreadLocal에 바인딩하도록 변경했습니다.
이렇게 해서 트랜잭션과 일반 DB 작업이 명확히 구분되어 테스트가 정상적으로 통과하게 되었습니다.

### 흐름

<img width="1110" height="1958" alt="Mermaid Chart - Create complex, visual diagrams with text -2025-10-12-095956" src="https://github.com/user-attachments/assets/76a3ce4c-42dd-4dc4-99b7-8c16fa53da70" />

### 이전 단계 코멘트 답변

>TransactionManager를 static으로 구현한 이유
저도 리뷰하다가 그 문제점을 알게되었는데요!
여러 DataSource를 사용하는 경우 (데이터에 따라 다른 DB를 쓰는 등,,)에 대비할 수 없더라구요!
Spring의 PlatformTransactionManager도 인스턴스 기반인 것도 여러 DataSource나 여러 트랜잭션 설정이 가능하도록 한 것이라네요!

그리고, 현재 TransactionManager는 initailize()를 하지 않으면 다른 메서드에서 사용 불가능한데, 그것을 강제로 하기 위해서는 생성자에서 초기화를 수행하는게 제일 나을거 같습니다!

그래서, 인스턴스 기반으로 수정했습니다!