### PR TITLE
[4단계 - Transaction synchronization 적용하기] - 체체(김진영) 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -2,7 +2,6 @@ package com.techcourse.dao;
 
 import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.domain.User;
-import java.sql.Connection;
 import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -29,12 +28,6 @@ public class UserDao {
         jdbcTemplate.update(sql, user.getAccount(), user.getPassword(), user.getEmail(), user.getId());
     }
 
-    public void updateWithConnection(final User user, final Connection connection) {
-        final var sql = "update users set account = ?, password = ?, email = ? where id = ?";
-        jdbcTemplate.updateWithConnection(sql, connection, user.getAccount(), user.getPassword(), user.getEmail(),
-                user.getId());
-    }
-
     public List<User> findAll() {
         final var sql = "select id, account, password, email from users";
         return jdbcTemplate.query(sql, userMapper);
@@ -43,11 +36,6 @@ public class UserDao {
     public Optional<User> findById(final Long id) {
         final var sql = "select id, account, password, email from users where id = ?";
         return jdbcTemplate.queryForObject(sql, userMapper, id);
-    }
-
-    public Optional<User> findByIdWithConnection(final Long id, final Connection connection) {
-        final var sql = "select id, account, password, email from users where id = ?";
-        return jdbcTemplate.queryForObjectWithConnection(sql, connection, userMapper, id);
     }
 
     public Optional<User> findByAccount(final String account) {

--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -2,7 +2,6 @@ package com.techcourse.dao;
 
 import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.domain.UserHistory;
-import java.sql.Connection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,10 +15,17 @@ public class UserHistoryDao {
         this.jdbcTemplate = jdbcTemplate;
     }
 
-    public void log(final UserHistory userHistory, final Connection connection) {
+    public void log(final UserHistory userHistory) {
         final var sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
-        jdbcTemplate.updateWithConnection(sql, connection, userHistory.getUserId(), userHistory.getAccount(),
+        jdbcTemplate.update(
+                sql,
+                userHistory.getUserId(),
+                userHistory.getAccount(),
                 userHistory.getPassword(),
-                userHistory.getEmail(), userHistory.getCreatedAt(), userHistory.getCreateBy());
+                userHistory.getEmail(),
+                userHistory.getCreatedAt(),
+                userHistory.getCreateBy()
+        );
+
     }
 }

--- a/app/src/main/java/com/techcourse/service/AppUserService.java
+++ b/app/src/main/java/com/techcourse/service/AppUserService.java
@@ -1,0 +1,41 @@
+package com.techcourse.service;
+
+import com.techcourse.dao.UserDao;
+import com.techcourse.dao.UserHistoryDao;
+import com.techcourse.domain.User;
+import com.techcourse.domain.UserHistory;
+
+public class AppUserService implements UserService {
+
+    private final UserDao userDao;
+    private final UserHistoryDao userHistoryDao;
+
+    public AppUserService(final UserDao userDao, final UserHistoryDao userHistoryDao) {
+        this.userDao = userDao;
+        this.userHistoryDao = userHistoryDao;
+    }
+
+    @Override
+    public User findById(final long id) {
+        return userDao.findById(id)
+                .orElseThrow(() -> new IllegalStateException("멤버가 존재하지 않습니다."));
+    }
+
+    @Override
+    public void save(final User user) {
+        userDao.insert(user);
+    }
+
+    @Override
+    public void changePassword(long id, String newPassword, String createdBy) {
+        User user = findUser(id);
+        user.changePassword(newPassword);
+        userDao.update(user);
+        userHistoryDao.log(new UserHistory(user, createdBy));
+    }
+
+    private User findUser(long id) {
+        return userDao.findById(id)
+                .orElseThrow(() -> new IllegalStateException("멤버가 존재하지 않습니다."));
+    }
+}

--- a/app/src/main/java/com/techcourse/service/TxUserService.java
+++ b/app/src/main/java/com/techcourse/service/TxUserService.java
@@ -1,0 +1,72 @@
+package com.techcourse.service;
+
+import com.interface21.jdbc.datasource.DataSourceUtils;
+import com.interface21.transaction.support.TransactionSynchronizationManager;
+import com.techcourse.config.DataSourceConfig;
+import com.techcourse.domain.User;
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+
+public class TxUserService implements UserService {
+
+    private final UserService userService;
+    private final DataSource dataSource;
+
+    public TxUserService(final UserService userService) {
+        this.userService = userService;
+        dataSource = DataSourceConfig.getInstance();
+    }
+
+    @Override
+    public User findById(final long id) {
+        return userService.findById(id);
+    }
+
+    @Override
+    public void save(final User user) {
+        userService.save(user);
+    }
+
+    @Override
+    public void changePassword(final long id, final String newPassword, final String createdBy) {
+        inTransaction(connection -> userService.changePassword(id, newPassword, createdBy));
+    }
+
+    @FunctionalInterface
+    private interface SqlConsumer<T> {
+        void accept(T t) throws Exception;
+    }
+
+    private void inTransaction(SqlConsumer<Connection> work) {
+        Connection connection = null;
+        try {
+            connection = DataSourceUtils.getConnection(dataSource);
+            connection.setAutoCommit(false);
+            TransactionSynchronizationManager.bindResource(dataSource, connection);
+            System.out.println(
+                    "[DEBUG] TxUserService connection=" + connection.hashCode() + ", closed=" + connection.isClosed());
+            try {
+                work.accept(connection);
+                connection.commit();
+            } catch (Exception ex) {
+                connection.rollback();
+                throwUncheckedException(ex);
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (connection != null) {
+                TransactionSynchronizationManager.unbindResource(dataSource);
+                DataSourceUtils.releaseConnection(connection, dataSource);
+            }
+        }
+    }
+
+    private void throwUncheckedException(Exception ex) {
+        if (ex instanceof RuntimeException re) {
+            throw re;
+        }
+        throw new RuntimeException(ex);
+    }
+}

--- a/app/src/main/java/com/techcourse/service/TxUserService.java
+++ b/app/src/main/java/com/techcourse/service/TxUserService.java
@@ -42,10 +42,9 @@ public class TxUserService implements UserService {
         Connection connection = null;
         try {
             connection = DataSourceUtils.getConnection(dataSource);
-            connection.setAutoCommit(false);
             TransactionSynchronizationManager.bindResource(dataSource, connection);
-            System.out.println(
-                    "[DEBUG] TxUserService connection=" + connection.hashCode() + ", closed=" + connection.isClosed());
+            connection.setAutoCommit(false);
+
             try {
                 work.accept(connection);
                 connection.commit();

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -1,80 +1,12 @@
 package com.techcourse.service;
 
-import com.interface21.jdbc.datasource.DataSourceUtils;
-import com.interface21.transaction.support.TransactionSynchronizationManager;
-import com.techcourse.config.DataSourceConfig;
-import com.techcourse.dao.UserDao;
-import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
-import com.techcourse.domain.UserHistory;
-import java.sql.Connection;
-import java.sql.SQLException;
-import javax.sql.DataSource;
 
-public class UserService {
+public interface UserService {
 
-    private final UserDao userDao;
-    private final UserHistoryDao userHistoryDao;
-    private final DataSource dataSource;
+    User findById(final long id);
 
-    public UserService(final UserDao userDao, final UserHistoryDao userHistoryDao) {
-        this.userDao = userDao;
-        this.userHistoryDao = userHistoryDao;
-        this.dataSource = DataSourceConfig.getInstance();
-    }
+    void save(final User user);
 
-    public User findById(final long id) {
-        return userDao.findById(id)
-                .orElseThrow(() -> new IllegalStateException("멤버가 존재하지 않습니다."));
-    }
-
-    public void insert(final User user) {
-        userDao.insert(user);
-    }
-
-    public void changePassword(long id, String newPassword, String createdBy) {
-        inTransaction(conn -> changePasswordTx(conn, id, newPassword, createdBy));
-    }
-
-    private void changePasswordTx(Connection conn, long id, String newPassword, String createdBy) {
-        User user = findUserForUpdate(conn, id);
-        user.changePassword(newPassword);
-        userDao.updateWithConnection(user, conn);
-        userHistoryDao.log(new UserHistory(user, createdBy), conn);
-    }
-
-    private User findUserForUpdate(Connection conn, long id) {
-        return userDao.findByIdWithConnection(id, conn)
-                .orElseThrow(() -> new IllegalStateException("멤버가 존재하지 않습니다."));
-    }
-
-    @FunctionalInterface
-    private interface SqlConsumer<T> {
-        void accept(T t) throws Exception;
-    }
-
-    private void inTransaction(SqlConsumer<Connection> work) {
-        try (Connection connection = DataSourceUtils.getConnection(dataSource)) {
-            connection.setAutoCommit(false);
-            try {
-                work.accept(connection);
-                connection.commit();
-            } catch (Exception ex) {
-                connection.rollback();
-                throwUncheckedException(ex);
-            } finally {
-                DataSourceUtils.releaseConnection(connection, dataSource);
-                TransactionSynchronizationManager.unbindResource(dataSource);
-            }
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private void throwUncheckedException(Exception ex) {
-        if (ex instanceof RuntimeException re) {
-            throw re;
-        }
-        throw new RuntimeException(ex);
-    }
+    void changePassword(final long id, final String newPassword, final String createdBy);
 }

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -1,5 +1,7 @@
 package com.techcourse.service;
 
+import com.interface21.jdbc.datasource.DataSourceUtils;
+import com.interface21.transaction.support.TransactionSynchronizationManager;
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
@@ -52,34 +54,20 @@ public class UserService {
     }
 
     private void inTransaction(SqlConsumer<Connection> work) {
-        try (Connection connection = dataSource.getConnection()) {
-            final boolean prevAutoCommit = connection.getAutoCommit();
+        try (Connection connection = DataSourceUtils.getConnection(dataSource)) {
             connection.setAutoCommit(false);
             try {
                 work.accept(connection);
                 connection.commit();
             } catch (Exception ex) {
-                rollback(connection);
+                connection.rollback();
                 throwUncheckedException(ex);
             } finally {
-                restoreAutoCommit(connection, prevAutoCommit);
+                DataSourceUtils.releaseConnection(connection, dataSource);
+                TransactionSynchronizationManager.unbindResource(dataSource);
             }
         } catch (SQLException e) {
             throw new RuntimeException(e);
-        }
-    }
-
-    private void rollback(Connection conn) {
-        try {
-            conn.rollback();
-        } catch (Exception ignore) {
-        }
-    }
-
-    private void restoreAutoCommit(Connection conn, boolean state) {
-        try {
-            conn.setAutoCommit(state);
-        } catch (Exception ignore) {
         }
     }
 

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -56,8 +56,7 @@ class UserDaoTest {
         final var user = new User(account, "password", "hkkang@woowahan.com");
         userDao.insert(user);
 
-        final var actual = userDao.findById(2L);
-
+        final var actual = userDao.findByAccount(account);
         assertThat(actual.get().getAccount()).isEqualTo(account);
     }
 
@@ -66,11 +65,9 @@ class UserDaoTest {
         final var newPassword = "password99";
         final var user = userDao.findByAccount("gugu");
         user.get().changePassword(newPassword);
-
         userDao.update(user.get());
 
         final var actual = userDao.findByAccount("gugu");
-
         assertThat(actual.get().getPassword()).isEqualTo(newPassword);
     }
 }

--- a/app/src/test/java/com/techcourse/service/AppUserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/AppUserServiceTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class UserServiceTest {
+class AppUserServiceTest {
 
     private JdbcTemplate jdbcTemplate;
     private UserDao userDao;
@@ -37,7 +37,7 @@ class UserServiceTest {
     @Test
     void testChangePassword() {
         final var userHistoryDao = new UserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao);
+        final var userService = new AppUserService(userDao, userHistoryDao);
 
         final var user = userDao.findByAccount("gugu");
         final var newPassword = "qqqqq";
@@ -50,17 +50,22 @@ class UserServiceTest {
 
     @Test
     void testTransactionRollback() {
+        // 트랜잭션 롤백 테스트를 위해 mock으로 교체
         final var userHistoryDao = new MockUserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao);
+        // 애플리케이션 서비스
+        final var appUserService = new AppUserService(userDao, userHistoryDao);
+        // 트랜잭션 서비스 추상화
+        final var userService = new TxUserService(appUserService);
 
-        final var user = userDao.findByAccount("gugu");
         final var newPassword = "newPassword";
         final var createdBy = "gugu";
-
+        final var user = userDao.findByAccount("gugu");
+        // 트랜잭션이 정상 동작하는지 확인하기 위해 의도적으로 MockUserHistoryDao에서 예외를 발생시킨다.
         assertThrows(DataAccessException.class,
                 () -> userService.changePassword(user.get().getId(), newPassword, createdBy));
 
         final var actual = userService.findById(user.get().getId());
+
         assertThat(actual.getPassword()).isNotEqualTo(newPassword);
     }
 }

--- a/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
+++ b/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
@@ -4,7 +4,6 @@ import com.interface21.dao.DataAccessException;
 import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.UserHistory;
-import java.sql.Connection;
 
 public class MockUserHistoryDao extends UserHistoryDao {
 
@@ -13,7 +12,7 @@ public class MockUserHistoryDao extends UserHistoryDao {
     }
 
     @Override
-    public void log(final UserHistory userHistory, final Connection connection) {
+    public void log(final UserHistory userHistory) {
         throw new DataAccessException();
     }
 }

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -10,6 +10,7 @@ import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -20,12 +21,17 @@ class UserServiceTest {
 
     @BeforeEach
     void setUp() {
-        this.jdbcTemplate = new JdbcTemplate(DataSourceConfig.getInstance());
-        this.userDao = new UserDao(jdbcTemplate);
+        DatabasePopulatorUtils.execute(DataSourceConfig.getInstance()); // DB 초기화
+        jdbcTemplate = new JdbcTemplate(DataSourceConfig.getInstance());
+        userDao = new UserDao(jdbcTemplate);
 
-        DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
         userDao.insert(user);
+    }
+
+    @AfterEach
+    void tearDown() {
+        userDao.deleteAll();
     }
 
     @Test
@@ -33,29 +39,28 @@ class UserServiceTest {
         final var userHistoryDao = new UserHistoryDao(jdbcTemplate);
         final var userService = new UserService(userDao, userHistoryDao);
 
+        final var user = userDao.findByAccount("gugu");
         final var newPassword = "qqqqq";
-        final var createBy = "gugu";
-        userService.changePassword(1L, newPassword, createBy);
+        final var createdBy = "gugu";
+        userService.changePassword(user.get().getId(), newPassword, createdBy);
 
-        final var actual = userService.findById(1L);
-
+        final var actual = userService.findById(user.get().getId());
         assertThat(actual.getPassword()).isEqualTo(newPassword);
     }
 
     @Test
     void testTransactionRollback() {
-        // 트랜잭션 롤백 테스트를 위해 mock으로 교체
         final var userHistoryDao = new MockUserHistoryDao(jdbcTemplate);
         final var userService = new UserService(userDao, userHistoryDao);
 
+        final var user = userDao.findByAccount("gugu");
         final var newPassword = "newPassword";
-        final var createBy = "gugu";
-        // 트랜잭션이 정상 동작하는지 확인하기 위해 의도적으로 MockUserHistoryDao에서 예외를 발생시킨다.
+        final var createdBy = "gugu";
+
         assertThrows(DataAccessException.class,
-                () -> userService.changePassword(1L, newPassword, createBy));
+                () -> userService.changePassword(user.get().getId(), newPassword, createdBy));
 
-        final var actual = userService.findById(1L);
-
+        final var actual = userService.findById(user.get().getId());
         assertThat(actual.getPassword()).isNotEqualTo(newPassword);
     }
 }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -33,7 +33,6 @@ public class JdbcTemplate {
         Connection conn = null;
         try {
             conn = DataSourceUtils.getConnection(dataSource);
-            System.out.println("[DEBUG] JdbcTemplate connection=" + conn.hashCode() + ", closed=" + conn.isClosed());
             try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
                 setParameters(pstmt, params);
                 pstmt.executeUpdate();

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -1,5 +1,6 @@
 package com.interface21.jdbc.core;
 
+import com.interface21.jdbc.datasource.DataSourceUtils;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -28,72 +29,41 @@ public class JdbcTemplate {
         return Optional.of(list.getFirst());
     }
 
-    public <T> Optional<T> queryForObjectWithConnection(String sql, Connection connection, RowMapper<T> mapper,
-                                                        Object... params) {
-        List<T> list = queryWithConnection(sql, connection, mapper, params);
-        if (list.isEmpty()) {
-            return Optional.empty();
-        }
-        if (list.size() > 1) {
-            throw new IllegalStateException("로우가 2개 이상");
-        }
-        return Optional.of(list.getFirst());
-    }
-
     public void update(String sql, Object... params) {
-        try (Connection conn = dataSource.getConnection();
-             PreparedStatement pstmt = conn.prepareStatement(sql)) {
-            setParameters(pstmt, params);
-            pstmt.executeUpdate();
+        Connection conn = null;
+        try {
+            conn = DataSourceUtils.getConnection(dataSource);
+            System.out.println("[DEBUG] JdbcTemplate connection=" + conn.hashCode() + ", closed=" + conn.isClosed());
+            try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
+                setParameters(pstmt, params);
+                pstmt.executeUpdate();
+            }
         } catch (SQLException e) {
             throw new RuntimeException("SQL 에러: " + e.getMessage(), e);
-        }
-    }
-
-    public void updateWithConnection(String sql, Connection connection, Object... params) {
-        try (
-                PreparedStatement pstmt = connection.prepareStatement(sql)) {
-            setParameters(pstmt, params);
-            pstmt.executeUpdate();
-        } catch (SQLException e) {
-            throw new RuntimeException("SQL 에러: " + e.getMessage(), e);
+        } finally {
+            DataSourceUtils.releaseConnection(conn, dataSource);
         }
     }
 
     public <T> List<T> query(String sql, RowMapper<T> mapper, Object... params) {
-        try (
-                Connection conn = dataSource.getConnection();
-                PreparedStatement pstmt = conn.prepareStatement(sql)
-        ) {
-            setParameters(pstmt, params);
-            try (ResultSet rs = pstmt.executeQuery()) {
-                List<T> results = new ArrayList<>();
-                int rowNum = 0;
-                while (rs.next()) {
-                    results.add(mapper.mapRow(rs, rowNum++));
+        Connection conn = null;
+        try {
+            conn = DataSourceUtils.getConnection(dataSource);
+            try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
+                setParameters(pstmt, params);
+                try (ResultSet rs = pstmt.executeQuery()) {
+                    List<T> results = new ArrayList<>();
+                    int rowNum = 0;
+                    while (rs.next()) {
+                        results.add(mapper.mapRow(rs, rowNum++));
+                    }
+                    return results;
                 }
-                return results;
             }
         } catch (SQLException e) {
             throw new RuntimeException("SQL 에러: " + e.getMessage(), e);
-        }
-    }
-
-    public <T> List<T> queryWithConnection(String sql, Connection connection, RowMapper<T> mapper, Object... params) {
-        try (
-                PreparedStatement pstmt = connection.prepareStatement(sql)
-        ) {
-            setParameters(pstmt, params);
-            try (ResultSet rs = pstmt.executeQuery()) {
-                List<T> results = new ArrayList<>();
-                int rowNum = 0;
-                while (rs.next()) {
-                    results.add(mapper.mapRow(rs, rowNum++));
-                }
-                return results;
-            }
-        } catch (SQLException e) {
-            throw new RuntimeException("SQL 에러: " + e.getMessage(), e);
+        } finally {
+            DataSourceUtils.releaseConnection(conn, dataSource);
         }
     }
 

--- a/jdbc/src/main/java/com/interface21/jdbc/datasource/DataSourceUtils.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/datasource/DataSourceUtils.java
@@ -13,15 +13,8 @@ public abstract class DataSourceUtils {
     }
 
     public static Connection getConnection(DataSource dataSource) throws CannotGetJdbcConnectionException {
-        Connection connection = TransactionSynchronizationManager.getResource(dataSource);
-        if (connection != null) {
-            return connection;
-        }
-
         try {
-            connection = dataSource.getConnection();
-            TransactionSynchronizationManager.bindResource(dataSource, connection);
-            return connection;
+            return dataSource.getConnection();
         } catch (SQLException ex) {
             throw new CannotGetJdbcConnectionException("Failed to obtain JDBC Connection", ex);
         }

--- a/jdbc/src/main/java/com/interface21/jdbc/datasource/DataSourceUtils.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/datasource/DataSourceUtils.java
@@ -2,15 +2,15 @@ package com.interface21.jdbc.datasource;
 
 import com.interface21.jdbc.CannotGetJdbcConnectionException;
 import com.interface21.transaction.support.TransactionSynchronizationManager;
-
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
+import javax.sql.DataSource;
 
 // 4단계 미션에서 사용할 것
 public abstract class DataSourceUtils {
 
-    private DataSourceUtils() {}
+    private DataSourceUtils() {
+    }
 
     public static Connection getConnection(DataSource dataSource) throws CannotGetJdbcConnectionException {
         Connection connection = TransactionSynchronizationManager.getResource(dataSource);
@@ -29,6 +29,10 @@ public abstract class DataSourceUtils {
 
     public static void releaseConnection(Connection connection, DataSource dataSource) {
         try {
+            Connection boundConnection = TransactionSynchronizationManager.getResource(dataSource);
+            if (boundConnection == connection) {
+                return;
+            }
             connection.close();
         } catch (SQLException ex) {
             throw new CannotGetJdbcConnectionException("Failed to close JDBC Connection");

--- a/jdbc/src/main/java/com/interface21/jdbc/datasource/DataSourceUtils.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/datasource/DataSourceUtils.java
@@ -13,6 +13,10 @@ public abstract class DataSourceUtils {
     }
 
     public static Connection getConnection(DataSource dataSource) throws CannotGetJdbcConnectionException {
+        Connection connection = TransactionSynchronizationManager.getResource(dataSource);
+        if (connection != null) {
+            return connection;
+        }
         try {
             return dataSource.getConnection();
         } catch (SQLException ex) {

--- a/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
+++ b/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
@@ -23,9 +23,4 @@ public abstract class TransactionSynchronizationManager {
     public static Connection unbindResource(DataSource key) {
         return resources.get().remove(key);
     }
-
-    public static void clear() {
-        resources.get().clear();
-        resources.remove();
-    }
 }

--- a/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
+++ b/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
@@ -1,23 +1,31 @@
 package com.interface21.transaction.support;
 
-import javax.sql.DataSource;
 import java.sql.Connection;
+import java.util.HashMap;
 import java.util.Map;
+import javax.sql.DataSource;
 
 public abstract class TransactionSynchronizationManager {
 
-    private static final ThreadLocal<Map<DataSource, Connection>> resources = new ThreadLocal<>();
+    private static final ThreadLocal<Map<DataSource, Connection>> resources = ThreadLocal.withInitial(HashMap::new);
 
-    private TransactionSynchronizationManager() {}
+    private TransactionSynchronizationManager() {
+    }
 
     public static Connection getResource(DataSource key) {
-        return null;
+        return resources.get().get(key);
     }
 
     public static void bindResource(DataSource key, Connection value) {
+        resources.get().put(key, value);
     }
 
     public static Connection unbindResource(DataSource key) {
-        return null;
+        return resources.get().remove(key);
+    }
+
+    public static void clear() {
+        resources.get().clear();
+        resources.remove();
     }
 }


### PR DESCRIPTION
안녕하세요 라젤~ 마지막 미션도 잘 부탁드립니다!

>메서드 이름에 WithConnection을 붙인 이유를 여쭈어 보고 싶습니다!
"Connection을 파라미터로 받는다"는 구현 세부사항을 노출하는 것인데, 구현 세부사항보다는 '왜' 이 메서드를 쓰는지 생각해서 네이밍 해보시는 것은 어떨까요?

라젤의 말에도 동의합니다~  트랜잭션 매니저를 사용하기 전에는 커넥션이 필수적으로 필요하게 됩니다.

하지만 이는 커넥션을 연결하는 곳에만 필요하게 됩니다. 따라서 명시적으로 네이밍으로 나타내는 것이 가독성 측면에서 좋다고 판단했어요.

물론 메서드 오버라이딩을 통해서 할 수 있지만, 처음 본 입장에서는 헷갈릴 수 있다고 생각해요.

>생성자에서는 받지 않고 DataSourceConfig.getInstance()를 통해 직접 가져오는데, 이렇게 한 이유가 궁금합니다.
의존성 주입 관점에서는 생성자로 받는 것이 더 좋을 것 같다고 생각하는데, 체체의 의견이 궁금합니다!

제 개인적인 생각으로는 사실 이 부분이 현재 미션에서 배우고자 하는 내용이 아니었기 때문에 간편하게 작성했어요!
추가적으로는 해당 부분에 의존성 주입을 통해 얻는 이점도 잘 모르겠다는 생각도 들었습니다.

>현재는 UserService에 private으로 있는데, 다른 Service에서도 트랜잭션이 필요하다면 어떻게 하면 좋을 까요? 🤔
제 생각에는 별도의 TransactionTemplate이나 유틸 클래스로 분리하는 것을 고려해 보는 것도 좋을 것 같네요! ☺️

맞습니다~ `inTransaction` 메서드를 유틸 클래스로 분리하는 게 좋아보여요. 하지만 현재로서는 하나라 ㅎㅎ 그 부분까지는 진행하지 않았어요. (분리에 더 관점을 맞추었습니다!)

>이렇게 하면:
람다 안에서 try-catch을 사용하지 않아도 된다.
예외 처리를 inTransaction 한 곳에서만 관리할 수 있다
비즈니스 로직을 깔끔하게 관리할 수 있다.
이런 이점들이 있는 것 같습니다!
제 이해가 맞는지 확인 부탁드립니다! (분명 리뷰인데... ㅋㅋ 학습 글이 되어 버렸네요..)

맞습니다 try-catch를 사용하고 싶지 않아 진행했어요.

>UserHistoryDao를 JdbcTemplate으로 변경하셨는데 그 이유를 물어봐도 될까요?

별다른 이유는 없어요 그냥 길어서 보기 싫었습니다 ..

