### PR TITLE
[4단계 - Transaction synchronization 적용하기] 우가(민보욱) 미션 제출합니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,55 @@
 
 ## JDBC 라이브러리 구현하기
 
-### 학습목표
-- JDBC 라이브러리를 구현하는 경험을 함으로써 중복을 제거하는 연습을 한다.
-- Transaction 적용을 위해 알아야할 개념을 이해한다.
+### 1. Transaction Synchronization
 
-### 시작 가이드
-1. 이전 미션에서 진행한 코드를 사용하고 싶다면, 마이그레이션 작업을 진행합니다.
-    - 학습 테스트는 강의 시간에 풀어봅시다.
-2. LMS의 1단계 미션부터 진행합니다.
+트랜잭션 관리하는 로직을 비즈니스 로직에서 분리하는 기술이다.
+`Connection`객체를 현재 실행 중인 스레드에 연결 시켜두는 것이 핵심이다.
 
-## 준비 사항
-- 강의 시작 전에 docker를 설치해주세요.
+**키워드**
 
-## 학습 테스트
-1. [ConnectionPool](study/src/test/java/connectionpool)
-2. [Transaction](study/src/test/java/transaction)
+- `ThreadLocal`: 각 스레드마다 고유한 저장 공간을 제공하는 자바 클래스
+    - A 스레드가 저장한 데이터는 B 스레드가 접근할 수 없다.
+
+### 2. 문제 해결 방식
+
+트랜잭션 동기화를 적용하더라돋, `UserService`가 여전히 `DataSource`에 의존적이고, `bindResource`, `unbindResourcd` 같은
+트랜잭션 관리 로직을 직접 수행해야 하는 문제가 남았음.
+
+이 문제를 해결하기 위해 `UserService`를 Interface로 만들고, 비즈니스 구현체와 트랜잭션 구현체를 구분함.
+
+1. `UserService` **(Interface)**
+    - 클라이언트가 의존하는 공통 인터페이스
+    - `findById`, `changePassword` 등 메서드를 정의함.
+
+2. `AppUserService` **(핵심 로직)**
+    - `UserService`인터페이스의 구현체다.
+    - `Connection`, `DataSourcd`, `Transaction`의 존재를 알지 못함.
+    - 오직 `UserDao`, `UserHistoryDao`를 호출하는 비즈니스 로직만 담당함!
+
+3. `TransactionUserService`
+    - `UserServic` 인터페이스의 트랜잭션 구현체다.
+    - `chnagePassword`와 같이 트랜잭션이 필요한 메서드는 직접 처리하고, `findById`처럼 필요 없는 메서드는 원본 객체에 그대로 위임한다.
+
+### 3. `TransactionUserService`의 작동 방식
+
+1. 트랜잭션 시작
+2. 커넥션 바인딩
+3. 핵심 로직 위임
+4. 트랜잭션 완료
+5. 리소스 정리 (풀 반납, 스레드 로컬 정리)
+
+### 4. `JdbcTemplate` 수정 사항
+
+`AppUserService`는 `Connection`을 모르지만, 그 내부의 `JdbcTemplate`는 트랜잭션에 참여해야함!
+`DataSourceUtils`로 해결이 됨!
+
+기존에 `dataSource.getConnection()`을 직접 호출하던 로직을 `DataSourceUtils.getConnection(dataSource)`로 변경했습니다.
+그리고, `Connection`을 닫던 로직을 `finally`에서 `DataSource.releaseConnection`로 변경했습니다.
+
+**`DataSourceUtils`의 역할**
+
+- `getConnection`은 `ThreadLocal`을 확인하는데, 트랜잭션 중이라면 저장해 둔 커넥션을 반환하고, 그렇지 않다면 새로운 커넥션을 반환합니다.
+- `releaseConnection`은 `ThreadLocal`을 확인하는데, 트랜잭션 중이라면 커넥션을 닫지 않고, 트랜잭션 밖이라면 커넥션을 닫습니다.
+    - 트랜잭션 매니저인 `TransactionUserService`가 닫도록 했습니다! 왜냐하면, 그 트랜잭션이 언제 완전히 끝나는지 아는 애는 트랜잭션 매니저니까입니다.
+    - `DataSourceUtils`는 트랜잭션의 주인이 아니니까!

--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -4,7 +4,6 @@ import com.interface21.jdbc.core.JdbcTemplate;
 import com.interface21.jdbc.core.PreparedStatementSetter;
 import com.interface21.jdbc.core.RowMapper;
 import com.techcourse.domain.User;
-import java.sql.Connection;
 import java.util.List;
 import java.util.Optional;
 
@@ -33,9 +32,9 @@ public class UserDao {
         jdbcTemplate.update(sql, pss);
     }
 
-    public void update(final User user, Connection connection) {
+    public void update(final User user) {
         final String sql = "update users set password = ?, email = ? where account = ?";
-        jdbcTemplate.update(connection, sql, user.getPassword(), user.getEmail(), user.getAccount());
+        jdbcTemplate.update(sql, user.getPassword(), user.getEmail(), user.getAccount());
     }
 
     public List<User> findAll() {

--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -3,13 +3,8 @@ package com.techcourse.dao;
 import com.interface21.jdbc.core.JdbcTemplate;
 import com.interface21.jdbc.core.PreparedStatementSetter;
 import com.techcourse.domain.UserHistory;
-import java.sql.Connection;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class UserHistoryDao {
-
-    private static final Logger log = LoggerFactory.getLogger(UserHistoryDao.class);
 
     private final JdbcTemplate jdbcTemplate;
 
@@ -17,7 +12,7 @@ public class UserHistoryDao {
         this.jdbcTemplate = jdbcTemplate;
     }
 
-    public void log(final UserHistory userHistory, final Connection connection) {
+    public void log(final UserHistory userHistory) {
         final var sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
         PreparedStatementSetter pss = ps -> {
             ps.setLong(1, userHistory.getUserId());
@@ -28,6 +23,6 @@ public class UserHistoryDao {
             ps.setString(6, userHistory.getCreateBy());
         };
 
-        jdbcTemplate.update(connection, sql, pss);
+        jdbcTemplate.update(sql, pss);
     }
 }

--- a/app/src/main/java/com/techcourse/service/AppUserService.java
+++ b/app/src/main/java/com/techcourse/service/AppUserService.java
@@ -1,0 +1,37 @@
+package com.techcourse.service;
+
+import com.techcourse.dao.UserDao;
+import com.techcourse.dao.UserHistoryDao;
+import com.techcourse.domain.User;
+import com.techcourse.domain.UserHistory;
+import java.util.NoSuchElementException;
+
+public class AppUserService implements UserService {
+
+    private final UserDao userDao;
+    private final UserHistoryDao userHistoryDao;
+
+    public AppUserService(final UserDao userDao, final UserHistoryDao userHistoryDao) {
+        this.userDao = userDao;
+        this.userHistoryDao = userHistoryDao;
+    }
+
+    @Override
+    public User findById(final long id) {
+        return userDao.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("User not found with id " + id));
+    }
+
+    @Override
+    public void insert(final User user) {
+        userDao.insert(user);
+    }
+
+    @Override
+    public void changePassword(final long id, final String newPassword, final String createdBy) {
+        final var user = findById(id);
+        user.changePassword(newPassword);
+        userDao.update(user);
+        userHistoryDao.log(new UserHistory(user, createdBy));
+    }
+}

--- a/app/src/main/java/com/techcourse/service/TransactionUserService.java
+++ b/app/src/main/java/com/techcourse/service/TransactionUserService.java
@@ -1,0 +1,63 @@
+package com.techcourse.service;
+
+import com.interface21.transaction.support.TransactionSynchronizationManager;
+import com.techcourse.domain.User;
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TransactionUserService implements UserService {
+
+    private static final Logger log = LoggerFactory.getLogger(TransactionUserService.class);
+
+    private final UserService userService;
+    private final DataSource dataSource;
+
+    public TransactionUserService(final UserService userService, final DataSource dataSource) {
+        this.userService = userService;
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public void changePassword(final long id, final String newPassword, final String createdBy) {
+        Connection connection = null;
+        try {
+            connection = dataSource.getConnection();
+            connection.setAutoCommit(false);
+            TransactionSynchronizationManager.bindResource(dataSource, connection);
+            userService.changePassword(id, newPassword, createdBy);
+            connection.commit();
+        } catch (Exception e) {
+            try {
+                if (connection != null) {
+                    connection.rollback();
+                }
+            } catch (SQLException ex) {
+                log.error("트랜잭션 롤백 실패", ex);
+            }
+            throw new RuntimeException("비밀번호 변경 중 오류 발생", e);
+        } finally {
+            try {
+                if (connection != null) {
+                    connection.close(); // 풀에 반납하고
+                }
+            } catch (SQLException e) {
+                log.error("커넥션 닫기 실패", e);
+            }
+            // 커넥션 제거 해줘야함
+            TransactionSynchronizationManager.unbindResource(dataSource);
+        }
+    }
+
+    @Override
+    public User findById(final long id) {
+        return userService.findById(id);
+    }
+
+    @Override
+    public void insert(final User user) {
+        userService.insert(user);
+    }
+}

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -1,61 +1,12 @@
 package com.techcourse.service;
 
-import com.techcourse.dao.UserDao;
-import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
-import com.techcourse.domain.UserHistory;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.NoSuchElementException;
-import javax.sql.DataSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class UserService {
+public interface UserService {
 
-    private static final Logger log = LoggerFactory.getLogger(UserService.class);
+    User findById(final long id);
 
-    private final UserDao userDao;
-    private final UserHistoryDao userHistoryDao;
-    private final DataSource dataSource;
+    void insert(final User user);
 
-    public UserService(final UserDao userDao, final UserHistoryDao userHistoryDao, final DataSource dataSource) {
-        this.userDao = userDao;
-        this.userHistoryDao = userHistoryDao;
-        this.dataSource = dataSource;
-    }
-
-    public User findById(final long id) {
-        return userDao.findById(id)
-                .orElseThrow(() -> new NoSuchElementException("User not found with id " + id));
-    }
-
-    public void insert(final User user) {
-        userDao.insert(user);
-    }
-
-    public void changePassword(final long id, final String newPassword, final String createBy) {
-        try (Connection connection = dataSource.getConnection()) {
-            try {
-                connection.setAutoCommit(false);
-                final var user = findById(id);
-                user.changePassword(newPassword);
-                userDao.update(user, connection);
-                userHistoryDao.log(new UserHistory(user, createBy), connection);
-
-                connection.commit();
-            } catch (Exception e) {
-                try {
-                    connection.rollback();
-                    log.warn("트랜잭션 롤백 성공", e);
-                } catch (SQLException ex) {
-                    log.error("롤백 실패", ex);
-                }
-                throw new RuntimeException("비밀번호 변경 중 오류가 발생하여 롤백했습니다.", e);
-            }
-        } catch (SQLException e) {
-            log.error("데이터베이스 연결 실패", e);
-            throw new RuntimeException("데이터베이스 연결에 실패했습니다.", e);
-        }
-    }
+    void changePassword(final long id, final String newPassword, final String createdBy);
 }

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -4,8 +4,6 @@ import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
-import java.sql.Connection;
-import java.sql.SQLException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -15,14 +13,12 @@ class UserDaoTest {
 
     private UserDao userDao;
     private JdbcTemplate jdbcTemplate;
-    private Connection connection;
 
     @BeforeEach
-    void setup() throws SQLException {
+    void setup() {
         var dataSource = DataSourceConfig.getInstance();
         this.jdbcTemplate = new JdbcTemplate(dataSource);
-        this.connection = dataSource.getConnection();
-        jdbcTemplate.update(connection, "DROP TABLE IF EXISTS users");
+        jdbcTemplate.update("DROP TABLE IF EXISTS users");
         DatabasePopulatorUtils.execute(dataSource);
         userDao = new UserDao(jdbcTemplate);
 
@@ -75,7 +71,7 @@ class UserDaoTest {
         final var user = userDao.findByAccount("gugu").orElseThrow();
         user.changePassword(newPassword);
 
-        userDao.update(user, connection);
+        userDao.update(user);
 
         assertThat(userDao.findByAccount("gugu"))
                 .isPresent()

--- a/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
+++ b/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
@@ -4,7 +4,6 @@ import com.interface21.dao.DataAccessException;
 import com.interface21.jdbc.core.JdbcTemplate;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.UserHistory;
-import java.sql.Connection;
 
 public class MockUserHistoryDao extends UserHistoryDao {
 
@@ -13,7 +12,7 @@ public class MockUserHistoryDao extends UserHistoryDao {
     }
 
     @Override
-    public void log(final UserHistory userHistory, final Connection connection) {
+    public void log(final UserHistory userHistory) {
         throw new DataAccessException("정상적인 롤백을 확인하기 위한 의도한 예외 발생");
     }
 }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -76,10 +76,10 @@ public class JdbcTemplate {
     }
 
     private int executeUpdate(final String sql, final PreparedStatementSetter pss) {
-        Connection connection = null;
+        Connection conn = null;
         try {
-            connection = getConnection();
-            try (final PreparedStatement ps = createPreparedStatement(connection, sql, pss)) {
+            conn = getConnection();
+            try (final PreparedStatement ps = createPreparedStatement(conn, sql, pss)) {
                 return ps.executeUpdate();
             }
         } catch (final SQLException e) {
@@ -87,7 +87,7 @@ public class JdbcTemplate {
             throw new DataAccessException("SQL 실행 실패", e);
         } finally {
             try {
-                DataSourceUtils.releaseConnection(connection, this.dataSource);
+                DataSourceUtils.releaseConnection(conn, this.dataSource);
             } catch (SQLException e) {
                 log.error("Connection 릴리즈 실패", e);
             }

--- a/jdbc/src/main/java/com/interface21/jdbc/datasource/DataSourceUtils.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/datasource/DataSourceUtils.java
@@ -1,37 +1,31 @@
 package com.interface21.jdbc.datasource;
 
-import com.interface21.jdbc.CannotGetJdbcConnectionException;
 import com.interface21.transaction.support.TransactionSynchronizationManager;
-
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
+import javax.sql.DataSource;
 
-// 4단계 미션에서 사용할 것
 public abstract class DataSourceUtils {
 
-    private DataSourceUtils() {}
-
-    public static Connection getConnection(DataSource dataSource) throws CannotGetJdbcConnectionException {
-        Connection connection = TransactionSynchronizationManager.getResource(dataSource);
-        if (connection != null) {
-            return connection;
-        }
-
-        try {
-            connection = dataSource.getConnection();
-            TransactionSynchronizationManager.bindResource(dataSource, connection);
-            return connection;
-        } catch (SQLException ex) {
-            throw new CannotGetJdbcConnectionException("Failed to obtain JDBC Connection", ex);
-        }
+    private DataSourceUtils() {
     }
 
-    public static void releaseConnection(Connection connection, DataSource dataSource) {
-        try {
-            connection.close();
-        } catch (SQLException ex) {
-            throw new CannotGetJdbcConnectionException("Failed to close JDBC Connection");
+    public static Connection getConnection(DataSource dataSource) throws SQLException {
+        Connection conn = (Connection) TransactionSynchronizationManager.getResource(dataSource);
+        if (conn != null) {
+            return conn;
+        }
+
+        return dataSource.getConnection();
+    }
+
+    public static void releaseConnection(Connection conn, DataSource dataSource) throws SQLException {
+        if (TransactionSynchronizationManager.hasResource(dataSource)) {
+            return;
+        }
+
+        if (conn != null) {
+            conn.close();
         }
     }
 }

--- a/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
+++ b/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
@@ -1,23 +1,43 @@
 package com.interface21.transaction.support;
 
-import javax.sql.DataSource;
-import java.sql.Connection;
+import java.util.HashMap;
 import java.util.Map;
 
 public abstract class TransactionSynchronizationManager {
 
-    private static final ThreadLocal<Map<DataSource, Connection>> resources = new ThreadLocal<>();
+    private static final ThreadLocal<Map<Object, Object>> resources = new ThreadLocal<>();
 
-    private TransactionSynchronizationManager() {}
-
-    public static Connection getResource(DataSource key) {
-        return null;
+    private TransactionSynchronizationManager() {
     }
 
-    public static void bindResource(DataSource key, Connection value) {
+    public static void init() {
+        if (resources.get() == null) {
+            resources.set(new HashMap<>());
+        }
     }
 
-    public static Connection unbindResource(DataSource key) {
-        return null;
+    public static void bindResource(Object key, Object value) {
+        init();
+        resources.get().put(key, value);
+    }
+
+    public static Object getResource(Object key) {
+        Map<Object, Object> map = resources.get();
+        return (map != null) ? map.get(key) : null;
+    }
+
+    public static void unbindResource(Object key) {
+        Map<Object, Object> map = resources.get();
+        if (map != null) {
+            map.remove(key);
+            if (map.isEmpty()) {
+                resources.remove();
+            }
+        }
+    }
+
+    public static boolean hasResource(Object key) {
+        Map<Object, Object> map = resources.get();
+        return (map != null) && map.containsKey(key);
     }
 }


### PR DESCRIPTION
안녕하세요, 대니!
마지막 미션의 마지막 step이네요 😄
잘 부탁드립니다!

구현을 진행하다 보니 한 가지 고민이 생겼어요.
지금의 구조를 유지한다면, 트랜잭션으로 관리가 필요한 서비스가 추가될 때마다 해당 서비스의 트랜잭션을 담당하는 클래스가 계속 늘어날 것 같다는 생각이 들었습니다.

그래서 이 구조에 대한 개선 방안을 조금 고민해봤는데요,
필수 요구사항은 아니어서 이번 구현에는 포함하지 않았지만,  템플릿패턴과 콜백을 활용하면 해결할 수 있을 것 같다는 아이디어가 들었어요.

트랜잭션 로직은 어떤 서비스에서도 반복적으로 사용되니까,
이를 템플릿으로 분리하고 → 트랜잭션이 필요한 서비스에 주입한 뒤 → 실제 비즈니스 로직은 콜백을 통해 실행하는 방식이 어떨까 생각했습니다.

혹시 대니도 이 부분에 대해 고민해보신 적이 있을까요?