### PR TITLE
[3단계 - Transaction 적용하기] 몽이(황재웅) 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -1,5 +1,7 @@
 package com.techcourse.dao;
 
+import com.interface21.jdbc.core.RowMapper;
+import com.techcourse.domain.User;
 import com.techcourse.domain.UserHistory;
 import com.interface21.jdbc.core.JdbcTemplate;
 import org.slf4j.Logger;
@@ -14,49 +16,23 @@ public class UserHistoryDao {
 
     private static final Logger log = LoggerFactory.getLogger(UserHistoryDao.class);
 
-    private final DataSource dataSource;
-
-    public UserHistoryDao(final DataSource dataSource) {
-        this.dataSource = dataSource;
-    }
+    private final JdbcTemplate jdbcTemplate;
 
     public UserHistoryDao(final JdbcTemplate jdbcTemplate) {
-        this.dataSource = null;
+        this.jdbcTemplate = jdbcTemplate;
     }
 
     public void log(final UserHistory userHistory) {
         final var sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
-
-        Connection conn = null;
-        PreparedStatement pstmt = null;
-        try {
-            conn = dataSource.getConnection();
-            pstmt = conn.prepareStatement(sql);
-
-            log.debug("query : {}", sql);
-
-            pstmt.setLong(1, userHistory.getUserId());
-            pstmt.setString(2, userHistory.getAccount());
-            pstmt.setString(3, userHistory.getPassword());
-            pstmt.setString(4, userHistory.getEmail());
-            pstmt.setObject(5, userHistory.getCreatedAt());
-            pstmt.setString(6, userHistory.getCreateBy());
-            pstmt.executeUpdate();
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
-        } finally {
-            try {
-                if (pstmt != null) {
-                    pstmt.close();
-                }
-            } catch (SQLException ignored) {}
-
-            try {
-                if (conn != null) {
-                    conn.close();
-                }
-            } catch (SQLException ignored) {}
-        }
+        final var hitRow = jdbcTemplate.update(
+                sql,
+                userHistory.getUserId(),
+                userHistory.getAccount(),
+                userHistory.getPassword(),
+                userHistory.getEmail(),
+                userHistory.getCreatedAt(),
+                userHistory.getCreateBy()
+        );
+        log.debug("Updated {} row(s) for user id: {}", hitRow, userHistory.getId());
     }
 }

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -48,7 +48,7 @@ public class UserService {
                 conn.setAutoCommit(false);
                 action.run();
                 conn.commit();
-            } catch (SQLException e) {
+            } catch (Exception e) {
                 try {
                     conn.rollback();
                 } catch (SQLException ex) {
@@ -57,12 +57,15 @@ public class UserService {
                 throw new DataAccessException("Transaction failed: " + e.getMessage());
             } finally {
                 try {
+                    conn.setAutoCommit(true);
                     conn.close();
                 } catch (SQLException e) {
                     log.error("Connection Close failed: {}", e.getMessage());
                 }
                 connectionManager.setConnection(null);
             }
+        } else {
+            throw new DataAccessException("No connection available for transaction");
         }
     }
 }

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -1,11 +1,18 @@
 package com.techcourse.service;
 
+import com.interface21.dao.DataAccessException;
+import com.interface21.jdbc.datasource.ConnectionManager;
 import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.domain.UserHistory;
+import java.sql.SQLException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class UserService {
+
+    private static final Logger log = LoggerFactory.getLogger(UserService.class);
 
     private final UserDao userDao;
     private final UserHistoryDao userHistoryDao;
@@ -24,9 +31,38 @@ public class UserService {
     }
 
     public void changePassword(final long id, final String newPassword, final String createBy) {
-        final var user = findById(id);
-        user.changePassword(newPassword);
-        userDao.update(user);
-        userHistoryDao.log(new UserHistory(user, createBy));
+        runInTransaction(() -> {
+            final var user = findById(id);
+            user.changePassword(newPassword);
+            userDao.update(user);
+            userHistoryDao.log(new UserHistory(user, createBy));
+        });
+    }
+
+    public void runInTransaction(Runnable action) {
+        final var connectionManager = ConnectionManager.getInstance();
+        final var connection = connectionManager.getConnection();
+        if (connection.isPresent()) {
+            final var conn = connection.get();
+            try {
+                conn.setAutoCommit(false);
+                action.run();
+                conn.commit();
+            } catch (SQLException e) {
+                try {
+                    conn.rollback();
+                } catch (SQLException ex) {
+                    log.error("Rollback failed: {}", e.getMessage());
+                }
+                throw new DataAccessException("Transaction failed: " + e.getMessage());
+            } finally {
+                try {
+                    conn.close();
+                } catch (SQLException e) {
+                    log.error("Connection Close failed: {}", e.getMessage());
+                }
+                connectionManager.setConnection(null);
+            }
+        }
     }
 }

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@Disabled
+
 class UserServiceTest {
 
     private JdbcTemplate jdbcTemplate;
@@ -45,6 +45,7 @@ class UserServiceTest {
     }
 
     @Test
+    @Disabled
     void testTransactionRollback() {
         // 트랜잭션 롤백 테스트를 위해 mock으로 교체
         final var userHistoryDao = new MockUserHistoryDao(jdbcTemplate);

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -1,18 +1,20 @@
 package com.techcourse.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.interface21.dao.DataAccessException;
+import com.interface21.jdbc.core.JdbcTemplate;
+import com.interface21.jdbc.datasource.ConnectionManager;
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
-import com.interface21.dao.DataAccessException;
-import com.interface21.jdbc.core.JdbcTemplate;
+import java.sql.SQLException;
+import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 class UserServiceTest {
@@ -21,17 +23,18 @@ class UserServiceTest {
     private UserDao userDao;
 
     @BeforeEach
-    void setUp() {
-        this.jdbcTemplate = new JdbcTemplate(DataSourceConfig.getInstance());
+    void setUp() throws SQLException {
+        DataSource dataSource = DataSourceConfig.getInstance();
+        ConnectionManager.getInstance().setConnection(DataSourceConfig.getInstance().getConnection());
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
         this.userDao = new UserDao(jdbcTemplate);
-
-        DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
+        DatabasePopulatorUtils.execute(dataSource);
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
         userDao.insert(user);
     }
 
     @Test
-    void testChangePassword() {
+    void testChangePassword() throws SQLException {
         final var userHistoryDao = new UserHistoryDao(jdbcTemplate);
         final var userService = new UserService(userDao, userHistoryDao);
 
@@ -45,8 +48,7 @@ class UserServiceTest {
     }
 
     @Test
-    @Disabled
-    void testTransactionRollback() {
+    void testTransactionRollback() throws SQLException {
         // 트랜잭션 롤백 테스트를 위해 mock으로 교체
         final var userHistoryDao = new MockUserHistoryDao(jdbcTemplate);
         final var userService = new UserService(userDao, userHistoryDao);

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -1,15 +1,17 @@
 package com.interface21.jdbc.core;
 
+import com.interface21.jdbc.datasource.ConnectionManager;
 import com.interface21.jdbc.exception.DataAccessException;
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.sql.DataSource;
 
 public class JdbcTemplate {
 
@@ -33,21 +35,21 @@ public class JdbcTemplate {
         });
     }
 
-    public <T> List<T> queryForList(final String sql,final RowMapper<T> rowMapper, final Object... params) {
+    public <T> List<T> queryForList(final String sql, final RowMapper<T> rowMapper, final Object... params) {
         return execute(sql, ps -> {
             setPreparedStatementParams(params, ps);
             return extractList(rowMapper, ps);
         });
     }
 
-    public int update(final String sql,final Object... params) {
+    public int update(final String sql, final Object... params) {
         return execute(sql, ps -> {
             setPreparedStatementParams(params, ps);
             return ps.executeUpdate();
         });
     }
 
-    private  <T> List<T> extractList(RowMapper<T> rowMapper, PreparedStatement ps)
+    private <T> List<T> extractList(RowMapper<T> rowMapper, PreparedStatement ps)
             throws SQLException {
         List<T> results = new ArrayList<>();
         try (ResultSet rs = ps.executeQuery()) {
@@ -66,15 +68,40 @@ public class JdbcTemplate {
 
     //https://github.com/spring-projects/spring-framework/blob/6aeb9d16e83c69d980f48a4a4f052bf52f31dfd0/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java#L654
     private <T> T execute(final String sql, final PreparedStatementCallback<T> action) {
-        try (final var conn = dataSource.getConnection();
-             final var ps = conn.prepareStatement(sql)) {
-
+        Connection conn = null;
+        PreparedStatement ps = null;
+        try {
+            conn = getConnection();
+            ps = conn.prepareStatement(sql);
             log.debug("query : {}", sql);
             return action.doInPreparedStatement(ps);
-
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
-            throw new DataAccessException("Jdbc Data Access Failed",e);
+            throw new DataAccessException("Jdbc Data Access Failed", e);
+        } finally {
+            close(ps, conn);
+        }
+    }
+
+    private Connection getConnection() throws SQLException {
+        Optional<Connection> conn = ConnectionManager.getInstance().getConnection();
+        return conn.orElse(dataSource.getConnection());
+    }
+
+    private void close(PreparedStatement ps, Connection conn) {
+        closeResource(ps);
+        if (!ConnectionManager.getInstance().isConnecting()) {
+            closeResource(conn);
+        }
+    }
+
+    private void closeResource(AutoCloseable resource) {
+        if (resource != null) {
+            try {
+                resource.close();
+            } catch (Exception e) {
+                log.error("Failed to close resource", e);
+            }
         }
     }
 }

--- a/jdbc/src/main/java/com/interface21/jdbc/datasource/ConnectionManager.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/datasource/ConnectionManager.java
@@ -1,0 +1,29 @@
+package com.interface21.jdbc.datasource;
+
+import java.sql.Connection;
+import java.util.Optional;
+
+public class ConnectionManager {
+
+    private static final ConnectionManager INSTANCE = new ConnectionManager();
+    private Connection connection;
+
+    private ConnectionManager() {
+    }
+
+    public static ConnectionManager getInstance() {
+        return INSTANCE;
+    }
+
+    public void setConnection(Connection connection) {
+        this.connection = connection;
+    }
+
+    public Optional<Connection> getConnection() {
+        return Optional.ofNullable(connection);
+    }
+
+    public boolean isConnecting() {
+        return connection != null;
+    }
+}


### PR DESCRIPTION
반갑습니다 플린트!
이번 미션에선 트랜잭션의 원자성을 보장하는 것이 요구사항이었습니다.
저는 트랜잭션 관리가 서비스의 역할이라 판단하여 DAO의 수정이 없는 코드를 목표로 진행해 보았습니다!

공통 커넥션을 저장하기 위한 `ConnectionManager`와 서비스 내부에서 트랜잭션을 관리하는 메서드 `runInTransaction()`를 두었습니다. 
조금 4단계의 내용을 담게 된 듯하여, 추상화를 더하는 것보단 현재의 요구사항을 만족하는 선에서만 마무리하였습니다.
이후엔 구구가 구현해준 `DataSourceUtils`와 `TransactionSynchronizationManager` 으로 대체될 것 같습니다!

