### PR TITLE
[4단계 - Transaction synchronization 적용하기] 벡터(백승주) 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -3,7 +3,6 @@ package com.techcourse.dao;
 import com.interface21.jdbc.core.JdbcTemplate;
 import com.interface21.jdbc.core.RowMapper;
 import com.techcourse.domain.User;
-import java.sql.Connection;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,11 +34,6 @@ public class UserDao {
         jdbcTemplate.update(sql, user.getAccount(), user.getPassword(), user.getEmail(), user.getId());
     }
 
-    public void update(final Connection connection, final User user) {
-        final var sql = "update users set account = ?, password = ?, email = ? where id = ?";
-        jdbcTemplate.update(connection, sql, user.getAccount(), user.getPassword(), user.getEmail(), user.getId());
-    }
-
     public List<User> findAll() {
         final var sql = "select id, account, password, email from users";
         return jdbcTemplate.queryForObjects(sql, userRowMapper);
@@ -50,17 +44,8 @@ public class UserDao {
         return jdbcTemplate.queryForObject(sql, userRowMapper, id);
     }
 
-    public User findById(final Connection connection, final Long id) {
-        final var sql = "select id, account, password, email from users where id = ?";
-        return jdbcTemplate.queryForObject(connection, sql, userRowMapper, id);
-    }
-
     public User findByAccount(final String account) {
         final var sql = "select id, account, password, email from users where account = ?";
         return jdbcTemplate.queryForObject(sql, userRowMapper, account);
-    }
-
-    public JdbcTemplate getJdbcTemplate() {
-        return jdbcTemplate;
     }
 }

--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -4,12 +4,8 @@ import com.interface21.jdbc.core.JdbcTemplate;
 import com.interface21.jdbc.core.RowMapper;
 import com.techcourse.domain.User;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class UserDao {
-
-    private static final Logger log = LoggerFactory.getLogger(UserDao.class);
 
     private final JdbcTemplate jdbcTemplate;
 

--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -5,8 +5,6 @@ import com.interface21.jdbc.core.JdbcTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.Connection;
-
 public class UserHistoryDao {
 
     private static final Logger log = LoggerFactory.getLogger(UserHistoryDao.class);
@@ -19,23 +17,12 @@ public class UserHistoryDao {
 
     public void log(final UserHistory userHistory) {
         final var sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
-        jdbcTemplate.update(sql, 
-            userHistory.getUserId(), 
-            userHistory.getAccount(), 
-            userHistory.getPassword(), 
-            userHistory.getEmail(), 
-            userHistory.getCreatedAt(), 
-            userHistory.getCreateBy());
-    }
-
-    public void log(final Connection connection, final UserHistory userHistory) {
-        final var sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
-        jdbcTemplate.update(connection, sql, 
-            userHistory.getUserId(), 
-            userHistory.getAccount(), 
-            userHistory.getPassword(), 
-            userHistory.getEmail(), 
-            userHistory.getCreatedAt(), 
+        jdbcTemplate.update(sql,
+            userHistory.getUserId(),
+            userHistory.getAccount(),
+            userHistory.getPassword(),
+            userHistory.getEmail(),
+            userHistory.getCreatedAt(),
             userHistory.getCreateBy());
     }
 }

--- a/app/src/main/java/com/techcourse/service/AppUserService.java
+++ b/app/src/main/java/com/techcourse/service/AppUserService.java
@@ -1,0 +1,35 @@
+package com.techcourse.service;
+
+import com.techcourse.dao.UserDao;
+import com.techcourse.dao.UserHistoryDao;
+import com.techcourse.domain.User;
+import com.techcourse.domain.UserHistory;
+
+public class AppUserService implements UserService {
+
+    private final UserDao userDao;
+    private final UserHistoryDao userHistoryDao;
+
+    public AppUserService(final UserDao userDao, final UserHistoryDao userHistoryDao) {
+        this.userDao = userDao;
+        this.userHistoryDao = userHistoryDao;
+    }
+
+    @Override
+    public User findById(final long id) {
+        return userDao.findById(id);
+    }
+
+    @Override
+    public void insert(final User user) {
+        userDao.insert(user);
+    }
+
+    @Override
+    public void changePassword(final long id, final String newPassword, final String createBy) {
+        final var user = userDao.findById(id);
+        user.changePassword(newPassword);
+        userDao.update(user);
+        userHistoryDao.log(new UserHistory(user, createBy));
+    }
+}

--- a/app/src/main/java/com/techcourse/service/TxUserService.java
+++ b/app/src/main/java/com/techcourse/service/TxUserService.java
@@ -6,8 +6,12 @@ import com.techcourse.domain.User;
 import java.sql.Connection;
 import java.sql.SQLException;
 import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TxUserService implements UserService {
+
+    private static final Logger log = LoggerFactory.getLogger(TxUserService.class);
 
     private final DataSource dataSource;
     private final UserService userService;
@@ -52,6 +56,7 @@ public class TxUserService implements UserService {
             try {
                 connection.rollback();
             } catch (SQLException e) {
+                log.error("Failed to rollback transaction", e);
             }
         }
     }
@@ -62,6 +67,7 @@ public class TxUserService implements UserService {
                 connection.setAutoCommit(true);
                 connection.close();
             } catch (SQLException e) {
+                log.error("Failed to close connection", e);
             }
         }
     }

--- a/app/src/main/java/com/techcourse/service/TxUserService.java
+++ b/app/src/main/java/com/techcourse/service/TxUserService.java
@@ -1,0 +1,69 @@
+package com.techcourse.service;
+
+import com.interface21.dao.DataAccessException;
+import com.interface21.jdbc.datasource.DataSourceUtils;
+import com.interface21.transaction.support.TransactionSynchronizationManager;
+import com.techcourse.domain.User;
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+
+public class TxUserService implements UserService {
+
+    private final DataSource dataSource;
+    private final UserService userService;
+
+    public TxUserService(final DataSource dataSource, final UserService userService) {
+        this.dataSource = dataSource;
+        this.userService = userService;
+    }
+
+    @Override
+    public User findById(final long id) {
+        return userService.findById(id);
+    }
+
+    @Override
+    public void insert(final User user) {
+        userService.insert(user);
+    }
+
+    @Override
+    public void changePassword(final long id, final String newPassword, final String createBy) {
+        Connection connection = null;
+        try {
+            connection = dataSource.getConnection();
+            connection.setAutoCommit(false);
+            TransactionSynchronizationManager.bindResource(dataSource, connection);
+
+            userService.changePassword(id, newPassword, createBy);
+
+            connection.commit();
+        } catch (Exception e) {
+            rollback(connection);
+            throw new DataAccessException(e);
+        } finally {
+            TransactionSynchronizationManager.unbindResource(dataSource);
+            close(connection);
+        }
+    }
+
+    private void rollback(final Connection connection) {
+        if (connection != null) {
+            try {
+                connection.rollback();
+            } catch (SQLException e) {
+            }
+        }
+    }
+
+    private void close(final Connection connection) {
+        if (connection != null) {
+            try {
+                connection.setAutoCommit(true);
+                connection.close();
+            } catch (SQLException e) {
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/techcourse/service/TxUserService.java
+++ b/app/src/main/java/com/techcourse/service/TxUserService.java
@@ -1,7 +1,6 @@
 package com.techcourse.service;
 
 import com.interface21.dao.DataAccessException;
-import com.interface21.jdbc.datasource.DataSourceUtils;
 import com.interface21.transaction.support.TransactionSynchronizationManager;
 import com.techcourse.domain.User;
 import java.sql.Connection;

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -63,6 +63,7 @@ public class UserService {
     private void close(final Connection connection) {
         if (connection != null) {
             try {
+                connection.setAutoCommit(true);
                 connection.close();
             } catch (SQLException e) {
             }

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -1,72 +1,12 @@
 package com.techcourse.service;
 
-import com.interface21.dao.DataAccessException;
-import com.techcourse.config.DataSourceConfig;
-import com.techcourse.dao.UserDao;
-import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
-import com.techcourse.domain.UserHistory;
-import java.sql.Connection;
-import java.sql.SQLException;
-import javax.sql.DataSource;
 
-public class UserService {
+public interface UserService {
 
-    private final UserDao userDao;
-    private final UserHistoryDao userHistoryDao;
-    private final DataSource dataSource;
+    User findById(final long id);
 
+    void insert(final User user);
 
-    public UserService(final UserDao userDao, final UserHistoryDao userHistoryDao) {
-        this.userDao = userDao;
-        this.userHistoryDao = userHistoryDao;
-        this.dataSource = DataSourceConfig.getInstance();
-    }
-
-    public User findById(final long id) {
-        return userDao.findById(id);
-    }
-
-    public void insert(final User user) {
-        userDao.insert(user);
-    }
-
-    public void changePassword(final long id, final String newPassword, final String createBy) {
-        Connection connection = null;
-        try {
-            connection = dataSource.getConnection();
-            connection.setAutoCommit(false);
-
-            final var user = userDao.findById(connection, id);
-            user.changePassword(newPassword);
-            userDao.update(connection, user);
-            userHistoryDao.log(connection, new UserHistory(user, createBy));
-
-            connection.commit();
-        } catch (SQLException e) {
-            rollback(connection);
-            throw new DataAccessException(e);
-        } finally {
-            close(connection);
-        }
-    }
-
-    private void rollback(final Connection connection) {
-        if (connection != null) {
-            try {
-                connection.rollback();
-            } catch (SQLException e) {
-            }
-        }
-    }
-
-    private void close(final Connection connection) {
-        if (connection != null) {
-            try {
-                connection.setAutoCommit(true);
-                connection.close();
-            } catch (SQLException e) {
-            }
-        }
-    }
+    void changePassword(final long id, final String newPassword, final String createBy);
 }

--- a/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
+++ b/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
@@ -5,8 +5,6 @@ import com.techcourse.domain.UserHistory;
 import com.interface21.dao.DataAccessException;
 import com.interface21.jdbc.core.JdbcTemplate;
 
-import java.sql.Connection;
-
 public class MockUserHistoryDao extends UserHistoryDao {
 
     public MockUserHistoryDao(final JdbcTemplate jdbcTemplate) {
@@ -15,11 +13,6 @@ public class MockUserHistoryDao extends UserHistoryDao {
 
     @Override
     public void log(final UserHistory userHistory) {
-        throw new DataAccessException();
-    }
-
-    @Override
-    public void log(final Connection connection, final UserHistory userHistory) {
         throw new DataAccessException();
     }
 }

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -31,7 +31,8 @@ class UserServiceTest {
     @Test
     void testChangePassword() {
         final var userHistoryDao = new UserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao);
+        final var appUserService = new AppUserService(userDao, userHistoryDao);
+        final var userService = new TxUserService(DataSourceConfig.getInstance(), appUserService);
 
         final var newPassword = "qqqqq";
         final var createBy = "gugu";
@@ -46,7 +47,8 @@ class UserServiceTest {
     void testTransactionRollback() {
         // 트랜잭션 롤백 테스트를 위해 mock으로 교체
         final var userHistoryDao = new MockUserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao);
+        final var appUserService = new AppUserService(userDao, userHistoryDao);
+        final var userService = new TxUserService(DataSourceConfig.getInstance(), appUserService);
 
         final var newPassword = "newPassword";
         final var createBy = "gugu";

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -26,28 +26,8 @@ public class JdbcTemplate {
         execute(sql, PreparedStatement::executeUpdate, args);
     }
 
-    public void update(Connection connection, String sql, Object... args) {
-        execute(connection, sql, PreparedStatement::executeUpdate, args);
-    }
-
     private <T> T execute(String sql, PreparedStatementCallback<T> callback, Object... args) {
-        Connection connection = null;
-        try {
-            connection = DataSourceUtils.getConnection(dataSource);
-            try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
-                log.debug("query : {}", sql);
-                setParameters(preparedStatement, args);
-                return callback.doInPreparedStatement(preparedStatement);
-            }
-        } catch (SQLException e) {
-            log.error("query 실패 {}", sql, e);
-            throw new DataAccessException(e);
-        } finally {
-            DataSourceUtils.releaseConnection(connection, dataSource);
-        }
-    }
-
-    private <T> T execute(Connection connection, String sql, PreparedStatementCallback<T> callback, Object... args) {
+        Connection connection = DataSourceUtils.getConnection(dataSource);
         try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
             log.debug("query : {}", sql);
             setParameters(preparedStatement, args);
@@ -55,6 +35,8 @@ public class JdbcTemplate {
         } catch (SQLException e) {
             log.error("query 실패 {}", sql, e);
             throw new DataAccessException(e);
+        } finally {
+            DataSourceUtils.releaseConnection(connection, dataSource);
         }
     }
 
@@ -78,33 +60,8 @@ public class JdbcTemplate {
         return execute(sql, callback, args);
     }
 
-    public <T> List<T> queryForObjects(Connection connection, String sql, RowMapper<T> rowMapper, Object... args) {
-        PreparedStatementCallback<List<T>> callback = preparedStatement -> {
-            try (ResultSet resultSet = preparedStatement.executeQuery()) {
-                List<T> results = new ArrayList<>();
-                int rowNum = 0;
-                while (resultSet.next()) {
-                    results.add(rowMapper.mapRow(resultSet, rowNum++));
-                }
-                return results;
-            }
-        };
-        return execute(connection, sql, callback, args);
-    }
-
     public <T> T queryForObject(String sql, RowMapper<T> rowMapper, Object... args) {
         List<T> results = queryForObjects(sql, rowMapper, args);
-        if (results.isEmpty()) {
-            throw new DataAccessException("일치하는 결과가 없습니다. ");
-        }
-        if (results.size() > 1) {
-            throw new DataAccessException("일치하는 결과가 1을 초과합니다.");
-        }
-        return results.get(0);
-    }
-
-    public <T> T queryForObject(Connection connection, String sql, RowMapper<T> rowMapper, Object... args) {
-        List<T> results = queryForObjects(connection, sql, rowMapper, args);
         if (results.isEmpty()) {
             throw new DataAccessException("일치하는 결과가 없습니다. ");
         }

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -1,6 +1,7 @@
 package com.interface21.jdbc.core;
 
 import com.interface21.dao.DataAccessException;
+import com.interface21.jdbc.datasource.DataSourceUtils;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -30,14 +31,19 @@ public class JdbcTemplate {
     }
 
     private <T> T execute(String sql, PreparedStatementCallback<T> callback, Object... args) {
-        try (Connection connection = dataSource.getConnection();
-             PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
-            log.debug("query : {}", sql);
-            setParameters(preparedStatement, args);
-            return callback.doInPreparedStatement(preparedStatement);
+        Connection connection = null;
+        try {
+            connection = DataSourceUtils.getConnection(dataSource);
+            try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+                log.debug("query : {}", sql);
+                setParameters(preparedStatement, args);
+                return callback.doInPreparedStatement(preparedStatement);
+            }
         } catch (SQLException e) {
             log.error("query 실패 {}", sql, e);
             throw new DataAccessException(e);
+        } finally {
+            DataSourceUtils.releaseConnection(connection, dataSource);
         }
     }
 

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -68,10 +68,6 @@ public class JdbcTemplate {
         if (results.size() > 1) {
             throw new DataAccessException("일치하는 결과가 1을 초과합니다.");
         }
-        return results.get(0);
-    }
-
-    public DataSource getDataSource() {
-        return dataSource;
+        return results.getFirst();
     }
 }

--- a/jdbc/src/main/java/com/interface21/jdbc/datasource/DataSourceUtils.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/datasource/DataSourceUtils.java
@@ -19,15 +19,22 @@ public abstract class DataSourceUtils {
         }
 
         try {
-            connection = dataSource.getConnection();
-            TransactionSynchronizationManager.bindResource(dataSource, connection);
-            return connection;
+            return dataSource.getConnection();
         } catch (SQLException ex) {
             throw new CannotGetJdbcConnectionException("Failed to obtain JDBC Connection", ex);
         }
     }
 
     public static void releaseConnection(Connection connection, DataSource dataSource) {
+        if (connection == null) {
+            return;
+        }
+
+        Connection boundConnection = TransactionSynchronizationManager.getResource(dataSource);
+        if (boundConnection == connection) {
+            return;
+        }
+
         try {
             connection.close();
         } catch (SQLException ex) {

--- a/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
+++ b/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
@@ -27,15 +27,14 @@ public abstract class TransactionSynchronizationManager {
         map.put(key, value);
     }
 
-    public static Connection unbindResource(DataSource key) {
+    public static void unbindResource(DataSource key) {
         final Map<DataSource, Connection> map = resources.get();
         if (map == null) {
-            return null;
+            return;
         }
-        final Connection connection = map.remove(key);
+        map.remove(key);
         if (map.isEmpty()) {
             resources.remove();
         }
-        return connection;
     }
 }

--- a/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
+++ b/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
@@ -11,13 +11,31 @@ public abstract class TransactionSynchronizationManager {
     private TransactionSynchronizationManager() {}
 
     public static Connection getResource(DataSource key) {
-        return null;
+        final Map<DataSource, Connection> map = resources.get();
+        if (map == null) {
+            return null;
+        }
+        return map.get(key);
     }
 
     public static void bindResource(DataSource key, Connection value) {
+        Map<DataSource, Connection> map = resources.get();
+        if (map == null) {
+            map = new java.util.HashMap<>();
+            resources.set(map);
+        }
+        map.put(key, value);
     }
 
     public static Connection unbindResource(DataSource key) {
-        return null;
+        final Map<DataSource, Connection> map = resources.get();
+        if (map == null) {
+            return null;
+        }
+        final Connection connection = map.remove(key);
+        if (map.isEmpty()) {
+            resources.remove();
+        }
+        return connection;
     }
 }


### PR DESCRIPTION
# 하~~~이~~~!!!!!! 수~~~양~~!!!

안녕하세요. 수수수수수 수퍼노바! 
벌써 우테코에서의 마지막 미션이라니 너무 슬프네요. (｡•́︿•̀｡)

마지막 리뷰어로 수양을 만나게 되어 영광이었습니다.

∧＿∧  　                       `       `                  ----⚾️pr `       `                     ----⚾️요청
( ·•︠‿•︡  )つ  ----⚾️step4       `       `                                             ----⚾️리뷰
(つ　 <  
｜　 _つ                                         
`し´

---

 이번 step에서는 요구사항에 따라 Transaction synchronization 을 적용하고 DataSourceUtils와 TransactionSynchronizationManager을 이용해 책임을 분산했습니다!

아래의 사항들은 이전 pr에서 남겨주신 리뷰들에 대한 답변입니다!

---

> 위에서 connection.setAutoCommit(false); 해주셨는데 되돌려놓아야 하지 않을까요?

Connection Pool을 사용할 경우, close()는 실제로 커넥션을 종료하는 게 아니라 풀에 반환하는 것이기 때문에 autoCommit을 false로 변경한 상태 그대로 반환하면 다음에 이 커넥션을 가져다 쓰는 곳에서 문제가 발생할 수 있기에 아래 커밋을 통해 개선했습니다.

https://github.com/woowacourse/java-jdbc/pull/1230/commits/ad09e17f137f514a79ec136ec070e314b075ac9c


> 오버로딩을 하면서 코드의 많은 부분이 중복된다는 느낌을 받았어요! 저도 마땅한 해결책이 떠오르지 않아서 비슷한 구조로 미션을 진행했는데, 어떻게하면 이런 중복 코드를 해결할 수 있을까요? 벡터의 생각이 궁금해요!

일단 4단계에서는 connection 관련 오버로딩 메서드가 불필요해지면서 중복 자체는 사라지긴 했지만만약 3단계에 머물렀다면, 중복 코드를 해결하기 위해 공통 로직을 별도 메서드로 추출하겠습니다.

 구체적으로 는 Connection을 받지 않는  메서드에서는 DataSource로부터 새로운 Connection을 획득한 후, Connection을 받는 메서드를 내부적으로 호출하는 방식으로 조금이나마 중복을 줄였을 것 같아요!

> 서비스 계층에서 데이터베이스 커넥션을 직접 관리하는 구조네요! 저는 미션을 수행할 당시 서비스 계층에게 너무 많은 권한을 부여하는건 아닐까 하는 고민이 들었는데 벡터의 생각은 어떠신가요?

 동의합니다! 서비스 계층에서 Connection을 직접 관리하는 것은 비즈니스 로직,트랜잭션 관리, 커넥션 관리, 등 너무 많은 권한과 관심사가 혼재되는 문제점이 있을 수 있다 생각해요.
  그리고 이러한 문제점은 4단게 요구사항을 통해 해결되었다고 생각합니다.  AppUserService 는 비즈니스 로직만 담당하고 TxUserService는 트랜잭션 관리만 담당하고 TransactionSynchronizationManager는 Connection 동기화를 담당해 관심사 혼재되는 문제가 해결되었습니다!


