### PR TITLE
[4단계 - Transaction synchronization 적용하기] 머랭 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -10,7 +10,6 @@ import com.techcourse.domain.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.Connection;
 import java.sql.SQLSyntaxErrorException;
 import java.util.List;
 
@@ -28,79 +27,6 @@ public class UserDao {
 
     public UserDao(final JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
-    }
-
-    public Connection getConnection() {
-        return jdbcTemplate.getConnection();
-    }
-
-    public void startTransaction(Connection connection) {
-        jdbcTemplate.startTransaction(connection);
-    }
-
-    public void commitTransaction(Connection connection) {
-        jdbcTemplate.commitTransaction(connection);
-    }
-
-    public void insertWithTransaction(final User user, final Connection connection) {
-        CommandSpecification specification = new CommandSpecification(createPreparedStatementSpecification(
-                "insert into users (account, password, email) values (?, ?, ?)",
-                List.of(
-                        new PreparedStatementParameter(1, user.getAccount()),
-                        new PreparedStatementParameter(2, user.getPassword()),
-                        new PreparedStatementParameter(3, user.getEmail())
-                )
-        ));
-        jdbcTemplate.insertWithTransaction(specification, connection);
-    }
-
-    public void updateWithTransaction(final User user, final Connection connection) {
-        CommandSpecification specification = new CommandSpecification(createPreparedStatementSpecification(
-                "update users set account = ?, password = ?, email = ? where id = ?",
-                List.of(
-                        new PreparedStatementParameter(1, user.getAccount()),
-                        new PreparedStatementParameter(2, user.getPassword()),
-                        new PreparedStatementParameter(3, user.getEmail()),
-                        new PreparedStatementParameter(4, user.getId())
-                )
-        ));
-        jdbcTemplate.updateWithTransaction(specification, connection);
-    }
-
-    public List<User> findAllWithTransaction(final Connection connection) {
-        QuerySpecification<User> specification = new QuerySpecification<>(
-                USER_ROW_MAPPER,
-                createPreparedStatementSpecification(
-                        "select id, account, password, email from users",
-                        List.of()
-                )
-        );
-        return jdbcTemplate.findAllWithTransaction(specification, connection);
-    }
-
-    public User findByIdWithTransaction(final Long id, final Connection connection) {
-        QuerySpecification<User> specification = new QuerySpecification<>(
-                USER_ROW_MAPPER,
-                createPreparedStatementSpecification(
-                        "select id, account, password, email from users where id = ?",
-                        List.of(new PreparedStatementParameter(1, id))
-                )
-        );
-        return jdbcTemplate.findOneWithTransaction(specification, connection)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
-    }
-
-    public User findByAccountWithTransaction(final String account, final Connection connection) {
-
-        QuerySpecification<User> specification = new QuerySpecification<>(
-                USER_ROW_MAPPER,
-                createPreparedStatementSpecification(
-                        "select id, account, password, email from users where account = ?",
-                        List.of(new PreparedStatementParameter(1, account))
-                )
-        );
-        return jdbcTemplate.findOneWithTransaction(specification, connection)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
     }
 
     public void insert(final User user) {

--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -10,7 +10,6 @@ import com.techcourse.domain.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.SQLSyntaxErrorException;
 import java.util.List;
 
 public class UserDao {
@@ -30,37 +29,42 @@ public class UserDao {
     }
 
     public void insert(final User user) {
-        CommandSpecification specification = new CommandSpecification(createPreparedStatementSpecification(
-                "insert into users (account, password, email) values (?, ?, ?)",
-                List.of(
-                        new PreparedStatementParameter(1, user.getAccount()),
-                        new PreparedStatementParameter(2, user.getPassword()),
-                        new PreparedStatementParameter(3, user.getEmail())
-                )
-        ));
+        CommandSpecification specification = new CommandSpecification(
+                PreparedStatementSpecification
+                        .builder("insert into users (account, password, email) values (?, ?, ?)")
+                        .parameters(
+                                List.of(
+                                        new PreparedStatementParameter(1, user.getAccount()),
+                                        new PreparedStatementParameter(2, user.getPassword()),
+                                        new PreparedStatementParameter(3, user.getEmail())
+                                )
+                        ).build()
+        );
         jdbcTemplate.insert(specification);
     }
 
     public void update(final User user) {
-        CommandSpecification specification = new CommandSpecification(createPreparedStatementSpecification(
-                "update users set account = ?, password = ?, email = ? where id = ?",
-                List.of(
-                        new PreparedStatementParameter(1, user.getAccount()),
-                        new PreparedStatementParameter(2, user.getPassword()),
-                        new PreparedStatementParameter(3, user.getEmail()),
-                        new PreparedStatementParameter(4, user.getId())
-                )
-        ));
+        CommandSpecification specification = new CommandSpecification(
+                PreparedStatementSpecification
+                        .builder("update users set account = ?, password = ?, email = ? where id = ?")
+                        .parameters(
+                                List.of(
+                                        new PreparedStatementParameter(1, user.getAccount()),
+                                        new PreparedStatementParameter(2, user.getPassword()),
+                                        new PreparedStatementParameter(3, user.getEmail()),
+                                        new PreparedStatementParameter(4, user.getId())
+                                )
+                        ).build()
+        );
         jdbcTemplate.update(specification);
     }
 
     public List<User> findAll() {
         QuerySpecification<User> specification = new QuerySpecification<>(
                 USER_ROW_MAPPER,
-                createPreparedStatementSpecification(
-                        "select id, account, password, email from users",
-                        List.of()
-                )
+                PreparedStatementSpecification
+                        .builder("select id, account, password, email from users")
+                        .build()
         );
         return jdbcTemplate.findAll(specification);
     }
@@ -68,10 +72,10 @@ public class UserDao {
     public User findById(final Long id) {
         QuerySpecification<User> specification = new QuerySpecification<>(
                 USER_ROW_MAPPER,
-                createPreparedStatementSpecification(
-                        "select id, account, password, email from users where id = ?",
-                        List.of(new PreparedStatementParameter(1, id))
-                )
+                PreparedStatementSpecification
+                        .builder("select id, account, password, email from users where id = ?")
+                        .parameters(List.of(new PreparedStatementParameter(1, id)))
+                        .build()
         );
         return jdbcTemplate.findOne(specification)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
@@ -81,26 +85,12 @@ public class UserDao {
 
         QuerySpecification<User> specification = new QuerySpecification<>(
                 USER_ROW_MAPPER,
-                createPreparedStatementSpecification(
-                        "select id, account, password, email from users where account = ?",
-                        List.of(new PreparedStatementParameter(1, account))
-                )
+                PreparedStatementSpecification
+                        .builder("select id, account, password, email from users where account = ?")
+                        .parameters(List.of(new PreparedStatementParameter(1, account)))
+                        .build()
         );
         return jdbcTemplate.findOne(specification)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
-    }
-
-    private PreparedStatementSpecification createPreparedStatementSpecification(
-            String sql,
-            List<PreparedStatementParameter> parameters
-    ) {
-        try {
-            return PreparedStatementSpecification
-                    .builder(sql)
-                    .parameters(parameters)
-                    .build();
-        } catch (SQLSyntaxErrorException e) {
-            throw new IllegalArgumentException(e);
-        }
     }
 }

--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -8,7 +8,6 @@ import com.techcourse.domain.UserHistory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.Connection;
 import java.sql.SQLSyntaxErrorException;
 import java.util.List;
 
@@ -37,23 +36,6 @@ public class UserHistoryDao {
                 )
         );
         jdbcTemplate.insert(commandSpecification);
-    }
-
-    public void logWithTransaction(final UserHistory userHistory, final Connection connection) {
-        CommandSpecification commandSpecification = new CommandSpecification(
-                createPreparedStatementSpecification(
-                        "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)",
-                        List.of(
-                                new PreparedStatementParameter(1, userHistory.getUserId()),
-                                new PreparedStatementParameter(2, userHistory.getAccount()),
-                                new PreparedStatementParameter(3, userHistory.getPassword()),
-                                new PreparedStatementParameter(4, userHistory.getEmail()),
-                                new PreparedStatementParameter(5, userHistory.getCreatedAt()),
-                                new PreparedStatementParameter(6, userHistory.getCreateBy())
-                        )
-                )
-        );
-        jdbcTemplate.insertWithTransaction(commandSpecification, connection);
     }
 
     private PreparedStatementSpecification createPreparedStatementSpecification(

--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -8,7 +8,6 @@ import com.techcourse.domain.UserHistory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.SQLSyntaxErrorException;
 import java.util.List;
 
 public class UserHistoryDao {
@@ -23,32 +22,20 @@ public class UserHistoryDao {
 
     public void log(final UserHistory userHistory) {
         CommandSpecification commandSpecification = new CommandSpecification(
-                createPreparedStatementSpecification(
-                        "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)",
-                        List.of(
-                                new PreparedStatementParameter(1, userHistory.getUserId()),
-                                new PreparedStatementParameter(2, userHistory.getAccount()),
-                                new PreparedStatementParameter(3, userHistory.getPassword()),
-                                new PreparedStatementParameter(4, userHistory.getEmail()),
-                                new PreparedStatementParameter(5, userHistory.getCreatedAt()),
-                                new PreparedStatementParameter(6, userHistory.getCreateBy())
-                        )
-                )
+                PreparedStatementSpecification
+                        .builder(
+                                "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)")
+                        .parameters(
+                                List.of(
+                                        new PreparedStatementParameter(1, userHistory.getUserId()),
+                                        new PreparedStatementParameter(2, userHistory.getAccount()),
+                                        new PreparedStatementParameter(3, userHistory.getPassword()),
+                                        new PreparedStatementParameter(4, userHistory.getEmail()),
+                                        new PreparedStatementParameter(5, userHistory.getCreatedAt()),
+                                        new PreparedStatementParameter(6, userHistory.getCreateBy())
+                                )
+                        ).build()
         );
         jdbcTemplate.insert(commandSpecification);
-    }
-
-    private PreparedStatementSpecification createPreparedStatementSpecification(
-            String sql,
-            List<PreparedStatementParameter> parameters
-    ) {
-        try {
-            return PreparedStatementSpecification
-                    .builder(sql)
-                    .parameters(parameters)
-                    .build();
-        } catch (SQLSyntaxErrorException e) {
-            throw new IllegalArgumentException(e);
-        }
     }
 }

--- a/app/src/main/java/com/techcourse/service/ApplicationUserService.java
+++ b/app/src/main/java/com/techcourse/service/ApplicationUserService.java
@@ -1,0 +1,35 @@
+package com.techcourse.service;
+
+import com.techcourse.dao.UserDao;
+import com.techcourse.dao.UserHistoryDao;
+import com.techcourse.domain.User;
+import com.techcourse.domain.UserHistory;
+
+public class ApplicationUserService implements UserService {
+
+    private final UserDao userDao;
+    private final UserHistoryDao userHistoryDao;
+
+    public ApplicationUserService(final UserDao userDao, final UserHistoryDao userHistoryDao) {
+        this.userDao = userDao;
+        this.userHistoryDao = userHistoryDao;
+    }
+
+    @Override
+    public User findById(final long id) {
+        return userDao.findById(id);
+    }
+
+    @Override
+    public void save(final User user) {
+        userDao.insert(user);
+    }
+
+    @Override
+    public void changePassword(final long id, final String newPassword, final String createBy) {
+        final var user = findById(id);
+        user.changePassword(newPassword);
+        userDao.update(user);
+        userHistoryDao.log(new UserHistory(user, createBy));
+    }
+}

--- a/app/src/main/java/com/techcourse/service/TransactionalUserService.java
+++ b/app/src/main/java/com/techcourse/service/TransactionalUserService.java
@@ -1,0 +1,49 @@
+package com.techcourse.service;
+
+import com.interface21.jdbc.CannotGetJdbcConnectionException;
+import com.interface21.jdbc.datasource.DataSourceUtils;
+import com.interface21.transaction.support.TransactionSynchronizationManager;
+import com.techcourse.config.DataSourceConfig;
+import com.techcourse.domain.User;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class TransactionalUserService implements UserService {
+
+    private final DataSource dataSource = DataSourceConfig.getInstance();
+    private final UserService userService;
+
+    public TransactionalUserService(final UserService userService) {
+        this.userService = userService;
+    }
+
+    @Override
+    public User findById(final long id) {
+        return userService.findById(id);
+    }
+
+    @Override
+    public void save(final User user) {
+        userService.save(user);
+    }
+
+    @Override
+    public void changePassword(final long id, final String newPassword, final String createdBy) {
+        try (Connection connection = DataSourceUtils.getConnection(dataSource)) {
+            try {
+                connection.setAutoCommit(false);
+                userService.changePassword(id, newPassword, createdBy);
+                connection.commit();
+            } catch (Exception e) {
+                connection.rollback();
+                throw e;
+            }
+        } catch (CannotGetJdbcConnectionException | SQLException e) {
+            throw new RuntimeException(dataSource.toString() + "로부터 커넥션을 획득하는 데에 실패했습니다.", e);
+        } finally {
+            TransactionSynchronizationManager.unbindResource(dataSource);
+        }
+    }
+}

--- a/app/src/main/java/com/techcourse/service/TransactionalUserService.java
+++ b/app/src/main/java/com/techcourse/service/TransactionalUserService.java
@@ -37,8 +37,11 @@ public class TransactionalUserService implements UserService {
                 userService.changePassword(id, newPassword, createdBy);
                 connection.commit();
             } catch (Exception e) {
-                connection.rollback();
-                throw e;
+                try {
+                    connection.rollback();
+                } catch (SQLException sqlException) {
+                    throw new RuntimeException("트랜잭션 롤백에 실패했습니다.", sqlException);
+                }
             }
         } catch (CannotGetJdbcConnectionException | SQLException e) {
             throw new RuntimeException(dataSource.toString() + "로부터 커넥션을 획득하는 데에 실패했습니다.", e);

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -1,43 +1,12 @@
 package com.techcourse.service;
 
-import com.techcourse.dao.UserDao;
-import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
-import com.techcourse.domain.UserHistory;
 
-import java.sql.Connection;
-import java.sql.SQLException;
+public interface UserService {
 
-public class UserService {
+    User findById(final long id);
 
-    private final UserDao userDao;
-    private final UserHistoryDao userHistoryDao;
+    void save(final User user);
 
-    public UserService(final UserDao userDao, final UserHistoryDao userHistoryDao) {
-        this.userDao = userDao;
-        this.userHistoryDao = userHistoryDao;
-    }
-
-    public User findById(final long id) {
-        return userDao.findById(id);
-    }
-
-    public void insert(final User user) {
-        userDao.insert(user);
-    }
-
-    public void changePassword(final long id, final String newPassword, final String createBy) throws SQLException {
-        final var user = findById(id);
-        user.changePassword(newPassword);
-        Connection connection = userDao.getConnection();
-        try {
-            userDao.startTransaction(connection);
-            userDao.updateWithTransaction(user, connection);
-            userHistoryDao.logWithTransaction(new UserHistory(user, createBy), connection);
-            userDao.commitTransaction(connection);
-        } catch (Exception e) {
-            connection.rollback();
-            throw e;
-        }
-    }
+    void changePassword(final long id, final String newPassword, final String createdBy);
 }

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -51,9 +51,6 @@ class UserDaoTest {
         final var account = "insert-gugu";
         final var user = new User(account, "password", "hkkang@woowahan.com");
         userDao.insert(user);
-        userDao.findAll().forEach(
-                u -> System.out.println("user = " + u)
-        );
 
         final var actual = userDao.findById(2L);
 

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -51,6 +51,9 @@ class UserDaoTest {
         final var account = "insert-gugu";
         final var user = new User(account, "password", "hkkang@woowahan.com");
         userDao.insert(user);
+        userDao.findAll().forEach(
+                u -> System.out.println("user = " + u)
+        );
 
         final var actual = userDao.findById(2L);
 

--- a/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
+++ b/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
@@ -12,7 +12,7 @@ public class MockUserHistoryDao extends UserHistoryDao {
     }
 
     @Override
-    public void logWithTransaction(final UserHistory userHistory, final java.sql.Connection connection) {
+    public void log(final UserHistory userHistory) {
         throw new DataAccessException();
     }
 }

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -10,8 +10,6 @@ import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.sql.SQLException;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -22,18 +20,17 @@ class UserServiceTest {
 
     @BeforeEach
     void setUp() {
+        DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
         this.jdbcTemplate = new JdbcTemplate(DataSourceConfig.getInstance());
         this.userDao = new UserDao(jdbcTemplate);
-
-        DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
         userDao.insert(user);
     }
 
     @Test
-    void testChangePassword() throws SQLException {
+    void testChangePassword() {
         final var userHistoryDao = new UserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao);
+        final var userService = new ApplicationUserService(userDao, userHistoryDao);
 
         final var newPassword = "qqqqq";
         final var createBy = "gugu";
@@ -48,18 +45,22 @@ class UserServiceTest {
     void testTransactionRollback() {
         // 트랜잭션 롤백 테스트를 위해 mock으로 교체
         final var userHistoryDao = new MockUserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao);
+        // 애플리케이션 서비스
+        final var appUserService = new ApplicationUserService(userDao, userHistoryDao);
+        // 트랜잭션 서비스 추상화
+        final var userService = new TransactionalUserService(appUserService);
 
         final var newPassword = "newPassword";
-        final var createBy = "gugu";
+        final var createdBy = "gugu";
         // 트랜잭션이 정상 동작하는지 확인하기 위해 의도적으로 MockUserHistoryDao에서 예외를 발생시킨다.
         assertThrows(
                 DataAccessException.class,
-                () -> userService.changePassword(1L, newPassword, createBy)
+                () -> userService.changePassword(1L, newPassword, createdBy)
         );
 
         final var actual = userService.findById(1L);
 
         assertThat(actual.getPassword()).isNotEqualTo(newPassword);
     }
+
 }

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -30,7 +30,7 @@ class UserServiceTest {
     @Test
     void testChangePassword() {
         final var userHistoryDao = new UserHistoryDao(jdbcTemplate);
-        final var userService = new ApplicationUserService(userDao, userHistoryDao);
+        final var userService = new TransactionalUserService(new ApplicationUserService(userDao, userHistoryDao));
 
         final var newPassword = "qqqqq";
         final var createBy = "gugu";

--- a/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/JdbcTemplate.java
@@ -10,6 +10,7 @@ import com.interface21.jdbc.core.execution.query.QueryExecution;
 import com.interface21.jdbc.core.execution.query.QuerySpecification;
 import com.interface21.jdbc.core.preparedstatement.PreparedStatementFactory;
 import com.interface21.jdbc.core.preparedstatement.PreparedStatementSpecification;
+import com.interface21.jdbc.datasource.DataSourceUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,55 +25,14 @@ public record JdbcTemplate(DataSource dataSource) {
 
     private static final Logger log = LoggerFactory.getLogger(JdbcTemplate.class);
 
-    public Connection getConnection() {
-        try {
-            return dataSource.getConnection();
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public void startTransaction(Connection connection) {
-        try {
-            connection.setAutoCommit(false);
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public void commitTransaction(Connection connection) {
-        try {
-            connection.commit();
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     private <T> T execute(
             PreparedStatementSpecification preparedStatementSpecification,
             PreparedStatementExecutor<T> preparedStatementExecutor
     ) {
+        Connection connection = DataSourceUtils.getConnection(dataSource);
         try (
-                Connection connection = dataSource.getConnection();
                 PreparedStatement preparedStatement = PreparedStatementFactory.initialize(
                         connection,
-                        preparedStatementSpecification
-                )
-        ) {
-            return preparedStatementExecutor.process(preparedStatement);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private <T> T executeWithTransaction(
-            PreparedStatementSpecification preparedStatementSpecification,
-            PreparedStatementExecutor<T> preparedStatementExecutor,
-            Connection externalConnection
-    ) {
-        try (
-                PreparedStatement preparedStatement = PreparedStatementFactory.initialize(
-                        externalConnection,
                         preparedStatementSpecification
                 )
         ) {
@@ -86,15 +46,6 @@ public record JdbcTemplate(DataSource dataSource) {
         return execute(specification.preparedStatementSpecification(), execution::execute);
     }
 
-    private int commandWithTransaction(
-            final CommandExecution execution,
-            final CommandSpecification specification,
-            final Connection externalConnection
-    ) {
-        return executeWithTransaction(
-                specification.preparedStatementSpecification(), execution::execute, externalConnection);
-    }
-
     private <T, R> R query(
             final QueryExecution<T, R> execution,
             final QuerySpecification<T> specification
@@ -105,50 +56,20 @@ public record JdbcTemplate(DataSource dataSource) {
         );
     }
 
-    private <T, R> R queryWithTransaction(
-            final QueryExecution<T, R> execution,
-            final QuerySpecification<T> specification,
-            final Connection externalConnection
-    ) {
-        return executeWithTransaction(
-                specification.preparedStatementSpecification(),
-                preparedStatement -> execution.execute(preparedStatement, specification),
-                externalConnection
-        );
-    }
-
     public int insert(final CommandSpecification specification) {
         return command(new CreateExecution(), specification);
-    }
-
-    public int insertWithTransaction(final CommandSpecification specification, Connection externalConnection) {
-        return commandWithTransaction(new CreateExecution(), specification, externalConnection);
     }
 
     public int update(final CommandSpecification specification) {
         return command(new UpdateExecution(), specification);
     }
 
-    public int updateWithTransaction(final CommandSpecification specification, Connection externalConnection) {
-        return commandWithTransaction(new UpdateExecution(), specification, externalConnection);
-    }
-
     public <T> Optional<T> findOne(final QuerySpecification<T> specification) {
         return query(new FindOneQueryExecution<>(), specification);
     }
 
-    public <T> Optional<T> findOneWithTransaction(
-            final QuerySpecification<T> specification, Connection externalConnection) {
-        return queryWithTransaction(new FindOneQueryExecution<>(), specification, externalConnection);
-    }
-
     public <T> List<T> findAll(final QuerySpecification<T> specification) {
         return query(new FindAllQueryExecution<>(), specification);
-    }
-
-    public <T> List<T> findAllWithTransaction(
-            final QuerySpecification<T> specification, Connection externalConnection) {
-        return queryWithTransaction(new FindAllQueryExecution<>(), specification, externalConnection);
     }
 
     private interface PreparedStatementExecutor<T> {

--- a/jdbc/src/main/java/com/interface21/jdbc/core/preparedstatement/PreparedStatementFactory.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/preparedstatement/PreparedStatementFactory.java
@@ -13,8 +13,8 @@ public class PreparedStatementFactory {
     ) throws SQLException {
         validateSpecification(specification);
 
-        PreparedStatement preparedStatement = connection.prepareStatement(specification.getSql());
-        for (PreparedStatementParameter parameter : specification.getParameters()) {
+        PreparedStatement preparedStatement = connection.prepareStatement(specification.sql());
+        for (PreparedStatementParameter parameter : specification.parameters()) {
             parameter.bind(preparedStatement);
         }
 
@@ -24,11 +24,11 @@ public class PreparedStatementFactory {
     private static void validateSpecification(
             PreparedStatementSpecification specification
     ) throws SQLSyntaxErrorException {
-        long placeholderCount = specification.getSql()
+        long placeholderCount = specification.sql()
                 .chars()
                 .filter(ch -> ch == '?')
                 .count();
-        long parameterCount = specification.getParameters().size();
+        long parameterCount = specification.parameters().size();
 
         if (placeholderCount != parameterCount) {
             throw new SQLSyntaxErrorException("PreparedStatementContext의 SQL과 파라미터의 개수가 일치하지 않습니다.");

--- a/jdbc/src/main/java/com/interface21/jdbc/core/preparedstatement/PreparedStatementSpecification.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/preparedstatement/PreparedStatementSpecification.java
@@ -6,16 +6,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-public class PreparedStatementSpecification {
+public record PreparedStatementSpecification(String sql, List<PreparedStatementParameter> parameters) {
 
-    final String sql;
-    final List<PreparedStatementParameter> parameters;
-
-    public PreparedStatementSpecification(
-            String sql, List<PreparedStatementParameter> parameters) throws SQLSyntaxErrorException {
+    public PreparedStatementSpecification {
         validateSpecification(sql, parameters);
-        this.sql = sql;
-        this.parameters = parameters;
     }
 
     public static Builder builder(String sql) {
@@ -25,7 +19,7 @@ public class PreparedStatementSpecification {
     private void validateSpecification(
             String sql,
             List<PreparedStatementParameter> parameters
-    ) throws SQLSyntaxErrorException {
+    ) {
         long placeholderCount = sql
                 .chars()
                 .filter(ch -> ch == '?')
@@ -33,16 +27,10 @@ public class PreparedStatementSpecification {
         long parameterCount = parameters.size();
 
         if (placeholderCount != parameterCount) {
-            throw new SQLSyntaxErrorException("PreparedStatementContext의 SQL과 파라미터의 개수가 일치하지 않습니다.");
+            throw new IllegalArgumentException(
+                    new SQLSyntaxErrorException("PreparedStatementContext의 SQL과 파라미터의 개수가 일치하지 않습니다.")
+            );
         }
-    }
-
-    public String getSql() {
-        return sql;
-    }
-
-    public List<PreparedStatementParameter> getParameters() {
-        return parameters;
     }
 
     public static class Builder {
@@ -68,7 +56,7 @@ public class PreparedStatementSpecification {
             return this;
         }
 
-        public PreparedStatementSpecification build() throws SQLSyntaxErrorException {
+        public PreparedStatementSpecification build() {
             return new PreparedStatementSpecification(
                     sql,
                     parameters

--- a/jdbc/src/main/java/com/interface21/jdbc/core/preparedstatement/PreparedStatementSpecification.java
+++ b/jdbc/src/main/java/com/interface21/jdbc/core/preparedstatement/PreparedStatementSpecification.java
@@ -8,6 +8,9 @@ import java.util.List;
 
 public record PreparedStatementSpecification(String sql, List<PreparedStatementParameter> parameters) {
 
+    /**
+     * @throws IllegalArgumentException
+     */
     public PreparedStatementSpecification {
         validateSpecification(sql, parameters);
     }
@@ -19,7 +22,7 @@ public record PreparedStatementSpecification(String sql, List<PreparedStatementP
     private void validateSpecification(
             String sql,
             List<PreparedStatementParameter> parameters
-    ) {
+    ) throws IllegalArgumentException {
         long placeholderCount = sql
                 .chars()
                 .filter(ch -> ch == '?')

--- a/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
+++ b/jdbc/src/main/java/com/interface21/transaction/support/TransactionSynchronizationManager.java
@@ -2,22 +2,37 @@ package com.interface21.transaction.support;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 public abstract class TransactionSynchronizationManager {
 
     private static final ThreadLocal<Map<DataSource, Connection>> resources = new ThreadLocal<>();
 
-    private TransactionSynchronizationManager() {}
+    private TransactionSynchronizationManager() {
+    }
 
     public static Connection getResource(DataSource key) {
-        return null;
+        return Optional.ofNullable(resources.get())
+                .map(map -> map.get(key))
+                .orElse(null);
     }
 
     public static void bindResource(DataSource key, Connection value) {
+        Optional.ofNullable(resources.get())
+                .ifPresentOrElse(
+                        map -> map.put(key, value),
+                        () -> {
+                            Map<DataSource, Connection> newMap = new HashMap<>();
+                            newMap.put(key, value);
+                            resources.set(newMap);
+                        }
+                );
     }
 
-    public static Connection unbindResource(DataSource key) {
-        return null;
+    public static void unbindResource(DataSource key) {
+        Optional.ofNullable(resources.get())
+                .ifPresent(map -> map.remove(key));
     }
 }

--- a/study/src/test/java/connectionpool/stage0/Stage0Test.java
+++ b/study/src/test/java/connectionpool/stage0/Stage0Test.java
@@ -41,7 +41,7 @@ class Stage0Test {
      * 구현체는 각 vendor에서 제공한다.
      * 테스트 코드의 JdbcDataSource 클래스는 h2에서 제공하는 클래스다.
      *
-     * DirverManager가 아닌 DataSource를 사용하는 이유
+     * DriverManager가 아닌 DataSource를 사용하는 이유
      * - 애플리케이션 코드를 직접 수정하지 않고 properties로 디비 연결을 변경할 수 있다.
      * - 커넥션 풀링(Connection pooling) 또는 분산 트랜잭션은 DataSource를 통해서 사용 가능하다.
      *


### PR DESCRIPTION
이제 마지막이네요 ㅎㅎ

이전 [이야기](https://github.com/woowacourse/java-jdbc/pull/1210#discussion_r2464571115) 를 반영했습니다.

기존에는 PreparedStatementSpecification의 생성자 시그니처에 throws 가 있었기 때문에, 사용하는쪽은 반드시 예외 핸들링을 해야 했습니다.
저는 제가 설계한 이 구조가 문제라고 판단했습니다.
메서드 시그니처에 예외를 명시하는 이유는 무엇일까요?
저는 "핸들링하지 않으면 큰일나는" 예외이기 때문이라 생각했습니다.

하지만, PreparedStatementSpecification 에서 명시하고 있는 SQLSyntaxErrorException는 핸들링하지 않아도 별 문제 없다고 생각합니다.
개발자의 잘못이고, 테스트 코드를 작성할 것이기 때문입니다.

따라서, 저는 PreparedStatementSpecification이 SQLSyntaxErrorException를 throw한다는 것을 시그니처에서 숨겼습니다.
이에 따라 Dao 들의 중복 코드도 자연스럽게 제거되었습니다.